### PR TITLE
Fixed create classroom crash

### DIFF
--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -832,9 +832,6 @@ function record_classroom(player,cc,sn,sy,sm,sd,ey,em,ed,map)
 				spawn_pos = { spawn_pos },
 			}
 		else
-			-- Need to recalculate local spawn position based on the last_map_pos
-			spawn_pos.x = spawn_pos.x + last_map_pos.x 
-			
 			table.insert(temp.course_code, cc)
 			table.insert(temp.section_number, sn)
 			table.insert(temp.start_year, sy)


### PR DESCRIPTION
There were two different lines recalculating the new spawn position for the newly placed map leading to spawn positions that were way off.