### PR TITLE
Move instantiation of `minetest_classroom` global object to its own mod

### DIFF
--- a/mods/magnify/mod.conf
+++ b/mods/magnify/mod.conf
@@ -1,2 +1,3 @@
 name = magnify
 description = Magnifying glass test (TBD)
+depends = mc_core

--- a/mods/mc_core/init.lua
+++ b/mods/mc_core/init.lua
@@ -1,0 +1,2 @@
+-- initialize minetest_classroom global object
+minetest_classroom = {}

--- a/mods/mc_core/mod.conf
+++ b/mods/mc_core/mod.conf
@@ -1,0 +1,2 @@
+name = mc_core
+description = Core utilities for the Minetest Classroom environment

--- a/mods/mc_student/mod.conf
+++ b/mods/mc_student/mod.conf
@@ -1,2 +1,3 @@
 name = mc_student
 description = Provides functions for students
+depends = mc_core, mc_teacher

--- a/mods/mc_teacher/init.lua
+++ b/mods/mc_teacher/init.lua
@@ -1,4 +1,3 @@
-minetest_classroom = {}
 minetest_classroom.classrooms = minetest.get_mod_storage()
 
 -- Required MT version

--- a/mods/mc_teacher/mod.conf
+++ b/mods/mc_teacher/mod.conf
@@ -1,2 +1,3 @@
 name = mc_teacher
 description = Provides formspec access to the teacher functions and abilities.
+depends = mc_core


### PR DESCRIPTION
Proposed patch for the issue brought up in #9
Additionally, adds dependencies to mod configuration files to ensure mods are loaded in the correct order on world startup