### PR TITLE
Removed "pointable" from the barrier node

### DIFF
--- a/mods/unbreakable_map_barrier/init.lua
+++ b/mods/unbreakable_map_barrier/init.lua
@@ -11,7 +11,8 @@ minetest.register_node("unbreakable_map_barrier:barrier", {
         on_destruct = function () end,
         can_dig = function() return false end,
         diggable = false,
-        drop = "",
+		pointable = false, -- The player can't highlight it
+		drop = "",
 })
 
 minetest.register_chatcommand("mapbarrier", {


### PR DESCRIPTION
Makes it so that the barrier block behaves more like air -- preventing players from using the barrier block to place nodes and removes the node selection that usually shows up.