### PR TITLE
Remove unnecessary call to `magnify`

### DIFF
--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -26,8 +26,6 @@ local infos = {
 local tool_name = "mc_teacher:controller"
 local priv_table = {"teacher"}
 
-local magnify = dofile(minetest.get_modpath("magnify") .. "/api.lua")
-
 -- Checks for the 'teacher' privilege
 local function check_perm_name(name)
     return minetest.check_player_privs(name, {teacher = true})


### PR DESCRIPTION
Removes an artifact from the old plant compendium implementation that was reintroduced while merging recent changes from `magnify` - this artifact coupled `magnify` and `mc_teacher`
