### PR TITLE
Feature/variable realm size

### DIFF
--- a/mods/mc_helpers/PointTable.lua
+++ b/mods/mc_helpers/PointTable.lua
@@ -17,7 +17,7 @@ function ptable.get(table, coords)
     return table[coords.x] and table[coords.x][coords.y] and table[coords.x][coords.y][coords.z]
 end
 function ptable.delete(table, coords)
-    if ptable.get(coords.x, coords.y, coords.z) == nil then
+    if ptable.get(table, coords) == nil then
         return
     end
     local tx = table[coords.x]

--- a/mods/mc_helpers/PointTable.lua
+++ b/mods/mc_helpers/PointTable.lua
@@ -1,0 +1,31 @@
+ptable = {}
+
+function ptable.store(table, coords, value)
+    local tx = table[coords.x]
+    if not tx then
+        tx = {}
+        table[coords.x] = tx
+    end
+    local ty = tx[coords.y]
+    if not ty then
+        ty = {}
+        tx[coords.y] = ty
+    end
+    ty[coords.z] = value
+end
+function ptable.get(table, coords)
+    return table[coords.x] and table[coords.x][coords.y] and table[coords.x][coords.y][coords.z]
+end
+function ptable.delete(table, coords)
+    if ptable.get(coords.x, coords.y, coords.z) == nil then
+        return
+    end
+    local tx = table[coords.x]
+    tx[coords.y][coords.z] = nil
+    if not next(tx[coords.y]) then
+        tx[coords.y] = nil
+        if not next(tx) then
+            table[coords.x] = nil
+        end
+    end
+end

--- a/mods/mc_helpers/init.lua
+++ b/mods/mc_helpers/init.lua
@@ -1,4 +1,5 @@
 dofile(minetest.get_modpath("mc_helpers") .. "/Debugging.lua")
+dofile(minetest.get_modpath("mc_helpers") .. "/PointTable.lua")
 
 mc_helpers = {}
 
@@ -102,3 +103,6 @@ function table.has(table, val)
     end
     return false
 end
+
+
+

--- a/mods/mc_helpers/init.lua
+++ b/mods/mc_helpers/init.lua
@@ -105,4 +105,25 @@ function table.has(table, val)
 end
 
 
+---@public
+---First sorts the keys into an array, and then iterates on the array. At each step, it returns the key and value from the original table
+---https://www.lua.org/pil/19.3.html
+---@param t table
+---@param f Optional order
+---@return function iterator
+function mc_helpers.pairsByKeys (t, f)
+    local a = {}
+    for n in pairs(t) do table.insert(a, n) end
+    table.sort(a, f)
+    local i = 0      -- iterator variable
+    local iter = function ()   -- iterator function
+        i = i + 1
+        if a[i] == nil then return nil
+        else return a[i], t[a[i]]
+        end
+    end
+    return iter
+end
+
+
 

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -162,3 +162,17 @@ minetest.register_chatcommand("realmSetSpawn", {
         return true, "Updated spawnpoint for realm with ID: " .. param
     end,
 })
+
+minetest.register_chatcommand("realmCleanup", {
+    privs = {
+        interact = true,
+    },
+    func = function(name, param)
+        Realm.consolidateEmptySpace()
+        Realm.SaveDataToStorage()
+        return true, "consolidated realms"
+    end,
+})
+
+
+

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -3,7 +3,7 @@
 
 minetest.register_chatcommand("realmNew", {
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         param = param or "Unnamed Realm"
@@ -17,7 +17,7 @@ minetest.register_chatcommand("realmNew", {
 minetest.register_chatcommand("realmDelete", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -34,7 +34,7 @@ minetest.register_chatcommand("realmDelete", {
 minetest.register_chatcommand("realmSchematic", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -50,7 +50,7 @@ minetest.register_chatcommand("realmSchematic", {
 
 minetest.register_chatcommand("realmList", {
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
 
@@ -68,7 +68,7 @@ minetest.register_chatcommand("realmList", {
 minetest.register_chatcommand("realmInfo", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -92,7 +92,7 @@ minetest.register_chatcommand("realmInfo", {
 minetest.register_chatcommand("realmTP", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -109,7 +109,7 @@ minetest.register_chatcommand("realmTP", {
 minetest.register_chatcommand("realmWalls", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -126,7 +126,7 @@ minetest.register_chatcommand("realmWalls", {
 minetest.register_chatcommand("localPos", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -146,7 +146,7 @@ minetest.register_chatcommand("localPos", {
 minetest.register_chatcommand("realmSetSpawn", {
     params = "Realm ID",
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         local requestedRealm = Realm.realmDict[tonumber(param)]
@@ -165,7 +165,7 @@ minetest.register_chatcommand("realmSetSpawn", {
 
 minetest.register_chatcommand("realmCleanup", {
     privs = {
-        interact = true,
+        teacher = true,
     },
     func = function(name, param)
         Realm.consolidateEmptySpace()

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -181,7 +181,6 @@ function Realm.CalculateStartEndPosition(areaInBlocks)
 end
 
 function Realm.markSpaceAsFree(startPos, endPos)
-
     local entry = {}
     entry.startPos = startPos
     entry.area = { x = endPos.x - startPos.x,
@@ -205,7 +204,6 @@ function Realm.consolidateEmptySpace()
             for y = entry.startPos.y, entry.startPos.y + entry.area.y do
                 for z = entry.startPos.z, entry.startPos.z + entry.area.z do
                     ptable.store(pointGrid, { x = x, y = y, z = z }, true)
-                    Debug.logCoords({ x = x, y = y, z = z }, "Point grid value: ")
                 end
             end
         end
@@ -356,11 +354,6 @@ function Realm.consolidateEmptySpace()
     -- TODO: If remove the tail end empty chunks after they're combined, and decrease our grid end position
     -- This will shrink our active address space and use less memory
 
-    for i, v in pairs(volumes) do
-        Debug.logCoords(v.startPos, i .. " startPos")
-        Debug.logCoords(v.area, i .. " area")
-    end
-
     Realm.EmptyChunks = volumes
 end
 
@@ -371,10 +364,17 @@ end
 function Realm:Delete()
     self:RunFunctionFromTable(self.RealmDeleteTable)
     self:ClearNodes()
-    Realm.markSpaceAsFree(Realm.worldToGridSpace({
-        x = self.StartPos.x - Realm.const.bufferSize,
-        y = self.StartPos.y - Realm.const.bufferSize,
-        z = self.StartPos.z - Realm.const.bufferSize }), Realm.worldToGridSpace(self.EndPos))
+
+    local gridSpace = Realm.worldToGridSpace({
+        x = self.StartPos.x,
+        y = self.StartPos.y,
+        z = self.StartPos.z })
+
+    gridSpace.x = gridSpace.x - Realm.const.bufferSize
+    gridSpace.y = gridSpace.y - Realm.const.bufferSize
+    gridSpace.z = gridSpace.z - Realm.const.bufferSize
+
+    Realm.markSpaceAsFree(gridSpace, Realm.worldToGridSpace(self.EndPos))
     Realm.realmDict[self.ID] = nil
     Realm.SaveDataToStorage()
 end

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -29,11 +29,9 @@ function Realm.gridToWorldSpace(coords)
 end
 
 function Realm.worldToGridSpace(coords)
-    Debug.logCoords(coords, "World Coords")
     local val = { x = 0, y = 0, z = 0 }
     val.x = math.ceil((coords.x + Realm.const.worldSize) / 80)
     val.y = math.ceil((coords.y + Realm.const.worldSize) / 80)
     val.z = math.ceil((coords.z + Realm.const.worldSize) / 80)
-    Debug.logCoords(val, "Grid Coords")
     return val
 end

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -31,9 +31,9 @@ end
 function Realm.worldToGridSpace(coords)
     Debug.logCoords(coords, "World Coords")
     local val = { x = 0, y = 0, z = 0 }
-    val.x = (coords.x + Realm.const.worldSize) / 80
-    val.y = (coords.y + Realm.const.worldSize) / 80
-    val.z = (coords.z + Realm.const.worldSize) / 80
+    val.x = math.ceil((coords.x + Realm.const.worldSize) / 80)
+    val.y = math.ceil((coords.y + Realm.const.worldSize) / 80)
+    val.z = math.ceil((coords.z + Realm.const.worldSize) / 80)
     Debug.logCoords(val, "Grid Coords")
     return val
 end


### PR DESCRIPTION
Finished variable realm size;

This PR:
1) Marks the unused space when creating new bins as empty
2) Reduces the amount of memory needed to keep track of empty world space by consolidating the list of empty chunks at server startup; 
3) supports bin resizing within gaps left by deleting realms (by-product of point 2).

The current iteration of the code is slow by nature of what it does with nested loops. That said, in testing with the creation (and subsequent deletion) of 10,000 realms, it was still very fast (took about 0.86 seconds on a Ryzen 3700x desktop; 2 seconds on an older mid-tier Intel I7 laptop) and reduced overall memory footprint. 

In the future, and depending on actual usage (such as if we have this code run more often), we might want to introduce more complicated algorithms to try to speed up the process, but for now, this is far more than sufficient.  