### PR TITLE
Fix node destruction on drop attempt

### DIFF
--- a/mods/magnify/init.lua
+++ b/mods/magnify/init.lua
@@ -66,8 +66,7 @@ minetest.register_tool(tool_name, {
         end
     end,
     -- makes the tool undroppable
-    on_drop = function (itemstack, dropper, pos)
-        minetest.set_node(pos, {name="air"})
+    on_drop = function(itemstack, dropper, pos)
     end
 })
 

--- a/mods/mc_student/init.lua
+++ b/mods/mc_student/init.lua
@@ -218,8 +218,7 @@ minetest.register_tool("mc_student:tutorialbook" , {
 		end
 	end,
 	-- Destroy the book on_drop to keep things tidy
-	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
+	on_drop = function(itemstack, dropper, pos)
 	end,
 })
 
@@ -516,8 +515,7 @@ minetest.register_tool(tool_name , {
 		end
 	end,
 	-- Destroy the controller on_drop to keep things tidy
-	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
+	on_drop = function(itemstack, dropper, pos)
 	end,
 })
 

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -909,7 +909,6 @@ minetest.register_tool(tool_name, {
     end,
     -- Destroy the controller on_drop so that students cannot pick it up (i.e, disallow dropping without first revoking teacher)
     on_drop = function(itemstack, dropper, pos)
-        minetest.set_node(pos, { name = "air" })
     end,
 })
 

--- a/mods/mc_teacher/init_old.lua
+++ b/mods/mc_teacher/init_old.lua
@@ -295,8 +295,7 @@ minetest.register_tool("mc_teacher:controller" , {
 		end
 	end,
 	-- Destroy the controller on drop so that students cannot pick it up
-	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
+	on_drop = function(itemstack, dropper, pos)
 	end,
 })
 

--- a/mods/mc_tutorial_framework/init.lua
+++ b/mods/mc_tutorial_framework/init.lua
@@ -106,8 +106,7 @@ minetest.register_tool("mc_tf:tutorialbook" , {
 		end
 	end,
 	-- Destroy the book on_drop to keep things tidy
-	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
+	on_drop = function(itemstack, dropper, pos)
 	end,
 })
 


### PR DESCRIPTION
Fixes #71 by removing the `minetest.set_node` line in the `on_drop` callback for each undroppable item