### PR TITLE
Add missing "end" statements to `mc_worldmanager`

### DIFF
--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -112,6 +112,9 @@ commands["schematic"] = function(name, params)
         minetest.chat_send_player(name, "Key : Filepath")
         for i, t in pairs(schematicManager.schematics) do
             minetest.chat_send_player(name, i .. " : " .. t)
+        end
+    end
+end
 
 commands["delete"] = {
     func = function(name, params)


### PR DESCRIPTION
Fixes a bug that prevents server startup due to missing `end` statements in `mc_worldmanager/commands.lua`