### PR TITLE
Prevent managed tools from being taken out of player inventory

### DIFF
--- a/mods/mc_toolhandler/README.md
+++ b/mods/mc_toolhandler/README.md
@@ -19,6 +19,10 @@ Additional properties need to be set for groups of similar tools (ex. a tool wit
 - `_mc_tool_group`: A group name for the tool, used to detect the presence of the tool instead of the tool name.
   - Usage: ```_mc_tool_group = "modname:generic_tool_name"```
 
+The following properties are optional:
+
+- `_mc_tool_allow_take`: Boolean flag indicating whether tool can be taken out of the player inventory. If unspecified, treated as `false`.
+
 ## Managing tools using `mc_toolhandler`
 
 To add tools to the list of tools handled by `mc_toolhandler`, follow the steps below:
@@ -26,4 +30,5 @@ To add tools to the list of tools handled by `mc_toolhandler`, follow the steps 
 - Add the name of the mod containg the tools you wish to manage (as defined in the mod's `mod.conf` file) to the `optional_depends` line of `mc_toolhandler`'s `mod.conf` file
   - `optional_depends` is a comma-separated list, so ensure that each mod in the list is separated by a comma
 - Define the `_mc_tool_privs` and/or `_mc_tool_include` fields in the tool definition for each tool you want `mc_toolhandler` to manage, as specified above
-- If applicable, define `_mc_tool_group` as specified above
+- If applicable, define the `_mc_tool_group` field for any tools that need it as specified above
+- Define optional properties for each tool as specified above, if desired

--- a/mods/mc_toolhandler/init.lua
+++ b/mods/mc_toolhandler/init.lua
@@ -286,6 +286,18 @@ local function remove_reg_duplications(player, stack, i, list)
     end
 end
 
+minetest.register_allow_player_inventory_action(function(player, action, inventory, inv_info)
+    if action == "take" then
+        local def = inv_info.stack:get_definition()
+        if not def._mc_tool_allow_take then
+            if mc_helpers.tableHas(mc_toolhandler.reg_tools, inv_info.stack:get_name()) or (def._mc_tool_group and mc_helpers.tableHas(mc_toolhandler.reg_tools, "group:"..def._mc_tool_group)) then
+                return 0 -- do not allow item to be taken
+            end
+        end
+    end
+    return -- ignore
+end)
+
 -- Register callback for removing duplicate tools
 minetest.register_on_player_inventory_action(function(player, action, inventory, inv_info)
     if action == "put" or action == "take" then


### PR DESCRIPTION
Adds support for the `_mc_tool_allow_take` property to `mc_toolhandler`, which is used for managing whether tools are allowed to be taken out of the player inventory
* Prevents tools from being moved into detached inventories, such as chest inventories

Unsure if this is a desired behaviour, hence why it is separate from #96 and #107