### PR TITLE
Feature/realm player groups

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/mods/ubc_map" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/mods/UBC_Campus_Minetest_Map" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/mods/areas" vcs="Git" />
   </component>
 </project>

--- a/mods/afkkick/init.lua
+++ b/mods/afkkick/init.lua
@@ -32,7 +32,9 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 minetest.register_on_chat_message(function(playerName, message)
-    players[playerName]["lastAction"] = minetest.get_gametime()
+    if (players[playerName] ~= nil) then
+        players[playerName].lastAction = minetest.get_gametime()
+    end
 end)
 
 minetest.register_globalstep(function(dtime)

--- a/mods/mc_helpers/Debugging.lua
+++ b/mods/mc_helpers/Debugging.lua
@@ -6,5 +6,6 @@ end
 
 function Debug.logCoords(coords, name)
     name = name or "unknown coords"
-    Debug.log(name .. ": " .. "X: " .. coords.x .. " Y: " .. coords.y .. " Z: " .. coords.z)
+
+    Debug.log(name .. ": " .. "X: " .. tostring(coords.x) .. " Y: " .. tostring(coords.y) .. " Z: " .. tostring(coords.z))
 end

--- a/mods/mc_helpers/init.lua
+++ b/mods/mc_helpers/init.lua
@@ -127,3 +127,24 @@ end
 function mc_helpers.trim(s)
     return s:match( "^%s*(.-)%s*$" )
 end
+
+
+function mc_helpers.shallowCopy(table)
+    local copy = {}
+    for k, v in pairs(table) do
+        copy[k] = v
+    end
+    return copy
+end
+
+function mc_helpers.deepCopy(table)
+    local copy = {}
+    for k, v in pairs(table) do
+        if type(v) == "table" then
+            copy[k] = mc_helpers.deepCopy(v)
+        else
+            copy[k] = v
+        end
+    end
+    return copy
+end

--- a/mods/mc_helpers/init.lua
+++ b/mods/mc_helpers/init.lua
@@ -123,3 +123,7 @@ function mc_helpers.pairsByKeys (t, f)
     end
     return iter
 end
+
+function mc_helpers.trim(s)
+    return s:match( "^%s*(.-)%s*$" )
+end

--- a/mods/mc_student/init.lua
+++ b/mods/mc_student/init.lua
@@ -107,8 +107,8 @@ local function record_coordinates(player,message)
 		temp = minetest.deserialize(pmeta:get_string("coordinates"))
 		if temp == nil then
 			datanew = {
-				coords = {"x="..math.floor(pos.x).." z="..math.floor(pos.y).." y="..math.floor(pos.z), }, 
-				notes = { message, }, 
+				coords = {"x="..math.floor(pos.x).." z="..math.floor(pos.y).." y="..math.floor(pos.z), },
+				notes = { message, },
 			}
 		else
 			table.insert(temp.coords, "x="..math.floor(pos.x).." z="..math.floor(pos.y).." y="..math.floor(pos.z))
@@ -151,7 +151,7 @@ local mc_student_accesscode_fail = {
 	"label[1.2,3.7;Please try again.]",
 	"button_exit[4.4,0;0.6,0.5;exit;X]"
 }
-	
+
 local function show_accesscode_fail(player)
 	if mc_helpers.checkPrivs(player,priv_table) then
 		local pname = player:get_player_name()
@@ -218,7 +218,7 @@ mc_student_mov = {
 	"button_exit[11,8.65;1.5,0.9;exit;Exit]"
 }
 
-local function show_mov(player) 
+local function show_mov(player)
 	if mc_helpers.checkPrivs(player,priv_table) then
 		local pname = player:get_player_name()
 		minetest.show_formspec(pname, "mc_student:mov", table.concat(mc_student_mov,""))
@@ -239,7 +239,7 @@ mc_student_punch = {
 	"button_exit[11,8.65;1.5,0.9;exit;Exit]"
 }
 
-local function show_punch(player) 
+local function show_punch(player)
 	if mc_helpers.checkPrivs(player,priv_table) then
 		local pname = player:get_player_name()
 		minetest.show_formspec(pname, "mc_student:punch", table.concat(mc_student_punch,""))
@@ -256,7 +256,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if string.sub(formname, 1, 10) ~= "mc_student" then
 		return false
 	end
-	
+
 	local wait = os.clock()
 	while os.clock() - wait < 0.05 do end --popups don't work without this
 
@@ -289,7 +289,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		-- Checking for nil (caused by player pressing escape instead of Back) ensures the game does not crash
 		elseif fields.report ~= " " and fields.report ~= nil then
 			local pname = player:get_player_name()
-			
+
 			-- Count the number of words, by counting for replaced spaces
 			-- Number of spaces = Number of words - 1
 			local _, count = string.gsub(fields.report, " ", "")
@@ -313,7 +313,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 					minetest.chat_send_player(teacher, minetest.colorize("#FF00FF", msg))
 				end
 			end
-			
+
 			-- Archive the report in mod storage
 			local key = pname.." "..tostring(os.date("%d-%m-%Y %H:%M:%S"))
 			minetest_classroom.reports:set_string(key,
@@ -327,7 +327,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			minetest.chat_send_player(player:get_player_name(),minetest.colorize("#FF0000","Error: Please add a message to your report."))
 		end
 	end
-	
+
 	if formname == "mc_student:marker" then
 		if fields.back then
 			show_student_menu(player)
@@ -337,7 +337,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			return true
 		end
 	end
-	
+
 	if formname == "mc_student:coordinates" then
 		if fields.back then
 			show_student_menu(player)
@@ -365,17 +365,17 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			show_coordinates(player)
 		end
 	end
-	
+
 	if formname == "mc_student:accesscode" or formname == "mc_student:accesscode_fail" then
 		if fields.exit then
 			return
 		end
-		
+
 		local pname = player:get_player_name()
-		
+
 		-- Get the classrooms from modstorage
 		local temp = minetest.deserialize(minetest_classroom.classrooms:get_string("classrooms"))
-			
+
 		if temp ~= nil then
 			-- Get the classroom accesscodes
 			local loc = check_access_code(fields.accesscode,temp.access_code)
@@ -396,6 +396,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 						end_year = { mdata.end_year[loc] },
 						end_month = { mdata.end_month[loc] },
 						end_day = { mdata.end_day[loc] },
+						realm_id = { mdata.realm_id[loc] },
 					}
 					pmeta:set_string("classrooms", minetest.serialize(classroomdata))
 				else
@@ -417,6 +418,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 						end_year = pdata.end_year,
 						end_month = pdata.end_month,
 						end_day = pdata.end_day,
+						realm_id = pdata.realm_id,
 					}
 				end
 
@@ -424,14 +426,19 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				if tonumber(mdata.end_year[loc]) < tonumber(os.date("%Y")) and months[mdata.end_month[loc]] < tonumber(os.date("%m")) and tonumber(mdata.end_day[loc]) < tonumber(os.date("%d")) then
 					minetest.chat_send_player(pname,pname..": The access code you entered has expired. Please contact your instructor.")
 				else
-					-- Send the student to the classroom spawn pos
-					player:set_pos(mdata.spawn_pos[loc])
+
+                    local realm = Realm.GetRealm(mdata.realm_id[loc])
+
+                    if (realm ~= nil) then
+                        realm:TeleportPlayer(player)
+                        minetest.chat_send_player(pname, pname .. ": You have been teleported to the classroom.")
+                    end
 				end
 			else
 				show_accesscode_fail(player)
-			end		
+			end
 		else
-			return	
+			return
 		end
 	end
 
@@ -513,7 +520,7 @@ function add_marker(pname, message, pos, owner)
 		})
 	end
 end
-	
+
 function markers.add(pname, msg, pos)
 
 	if markers[pname] then
@@ -616,7 +623,7 @@ function place_marker(player,message)
 			true, false
 		))
 		local pointed = ray:next()
-		
+
 		if message == "" then
 			message = "Look here!"
 		end

--- a/mods/mc_teacher/api.lua
+++ b/mods/mc_teacher/api.lua
@@ -71,12 +71,10 @@ function minetest_classroom.get_all_groups()
 end
 
 function minetest_classroom.get_group(name)
-	name = mc_helpers.trim(name)
 	return _groups[name]
 end
 
 function minetest_classroom.create_group(name)
-	name = mc_helpers.trim(name)
 	if _groups[name] or #name == 0 then
 		return nil
 	end
@@ -94,7 +92,6 @@ function minetest_classroom.create_group(name)
 end
 
 function minetest_classroom.remove_group(name)
-	name = mc_helpers.trim(name)
 	_groups[name].students = nil
 	_groups[name].name = nil
 	_groups[name] = nil

--- a/mods/mc_teacher/api.lua
+++ b/mods/mc_teacher/api.lua
@@ -90,6 +90,15 @@ function minetest_classroom.create_group(name)
 	return group
 end
 
+function minetest_classroom.remove_group(name)
+	_groups[name].students = nil
+	_groups[name].name = nil
+	_groups[name] = nil
+
+	minetest_classroom.save()
+end
+
+
 function minetest_classroom.add_student_to_group(name, student)
 	local group = minetest_classroom.get_group(name)
 	if group then

--- a/mods/mc_teacher/api.lua
+++ b/mods/mc_teacher/api.lua
@@ -2,165 +2,189 @@ local _groups = {}
 local _action_by_name = {}
 local _actions = {}
 
+
+
 -- Load data from MetaDataRef
 function minetest_classroom.load_from(meta)
-	local groups_str = meta:get("groups")
-	if not groups_str then
-		return
-	end
+    local groups_str = meta:get("groups")
+    if not groups_str then
+        return
+    end
 
-	_groups = minetest.deserialize(groups_str)
+    _groups = minetest.deserialize(groups_str)
+
+    -- the GUI is not extensible, so we are using the groups list to inject a tab as a work-around.
+    _groups["Realm"] = {
+        name = "Realm",
+        students = { } -- empty list to save memory. The UI does not use this.
+    }
 end
 
 -- Save data to MetaDataRef
 function minetest_classroom.save_to(meta)
-	meta:set_string("groups", minetest.serialize(_groups))
+    meta:set_string("groups", minetest.serialize(_groups))
 end
 
 function minetest_classroom.save()
-	-- Overridden in init.lua
+    -- Overridden in init.lua
 end
 
 function minetest_classroom.get_students()
-	local students = {}
-	for _, player in pairs(minetest_classroom.get_connected_players()) do
-		if not minetest_classroom.check_player_privs(player, { teacher = true }) then
-			students[#students + 1] = player:get_player_name()
-		end
-	end
+    local students = {}
+    for _, player in pairs(minetest_classroom.get_connected_players()) do
+        if not minetest_classroom.check_player_privs(player, { teacher = true }) then
+            students[#students + 1] = player:get_player_name()
+        end
+    end
 
-	return students
+    return students
 end
 
 function minetest_classroom.get_group_students(name)
-	name = mc_helpers.trim(name)
-	local group = minetest_classroom.get_group(name)
-	if not group then
-		return nil
-	end
+    name = mc_helpers.trim(name)
+    local group = minetest_classroom.get_group(name)
+    if not group then
+        return nil
+    end
 
-	local students = {}
-	for _, student in pairs(group.students) do
-		if minetest_classroom.get_player_by_name(student) then
-			students[#students + 1] = student
-		end
-	end
+    local students = {}
+    for _, student in pairs(group.students) do
+        if minetest_classroom.get_player_by_name(student) then
+            students[#students + 1] = student
+        end
+    end
 
-	return students
+    return students
 end
 
 function minetest_classroom.get_students_except(students)
-	local student_by_name = {}
-	for _, name in pairs(students) do
-		student_by_name[name] = true
-	end
+    local student_by_name = {}
+    for _, name in pairs(students) do
+        student_by_name[name] = true
+    end
 
-	local retval = {}
-	for _, player in pairs(minetest_classroom.get_connected_players()) do
-		if not student_by_name[player:get_player_name()] and
-				not minetest_classroom.check_player_privs(player, { teacher = true }) then
-			retval[#retval + 1] = player:get_player_name()
-		end
-	end
+    local retval = {}
+    for _, player in pairs(minetest_classroom.get_connected_players()) do
+        if not student_by_name[player:get_player_name()] and
+                not minetest_classroom.check_player_privs(player, { teacher = true }) then
+            retval[#retval + 1] = player:get_player_name()
+        end
+    end
 
-	return retval
+    return retval
 end
 
 function minetest_classroom.get_all_groups()
-	return _groups
+    return _groups
+end
+
+function minetest_classroom.get_realm_students(realmID)
+    local realm = Realm.GetRealm(realmID)
+    if not realm then
+        return nil
+    end
+
+    local students = {}
+    for _, student in pairs(realm:GetPlayersAsArray()) do
+
+        if minetest_classroom.get_player_by_name(student) and not minetest_classroom.check_player_privs(student, { teacher = true }) then
+            students[#students + 1] = student
+        end
+    end
+
+    return students
 end
 
 function minetest_classroom.get_group(name)
-	return _groups[name]
+    return _groups[name]
 end
 
 function minetest_classroom.create_group(name)
-	if _groups[name] or #name == 0 then
-		return nil
-	end
+    if _groups[name] or #name == 0 then
+        return nil
+    end
 
-	local group = {
-		name = name,
-		students = {},
-	}
+    local group = {
+        name = name,
+        students = {},
+    }
 
-	_groups[name] = group
+    _groups[name] = group
 
-	minetest_classroom.save()
+    minetest_classroom.save()
 
-	return group
+    return group
 end
 
 function minetest_classroom.remove_group(name)
-	_groups[name].students = nil
-	_groups[name].name = nil
-	_groups[name] = nil
+    _groups[name].students = nil
+    _groups[name].name = nil
+    _groups[name] = nil
 
-	minetest_classroom.save()
+    minetest_classroom.save()
 end
 
-
 function minetest_classroom.add_student_to_group(name, student)
-	local group = minetest_classroom.get_group(name)
-	if group then
-		for i=1, #group.students do
-			if group.students[i] == student then
-				return
-			end
-		end
+    local group = minetest_classroom.get_group(name)
+    if group then
+        for i = 1, #group.students do
+            if group.students[i] == student then
+                return
+            end
+        end
 
-		group.students[#group.students + 1] = student
+        group.students[#group.students + 1] = student
 
-		minetest_classroom.save()
-	end
+        minetest_classroom.save()
+    end
 end
 
 function minetest_classroom.remove_student_from_group(name, student)
-	local group = minetest_classroom.get_group(name)
-	if group then
-		for i=1, #group.students do
-			if group.students[i] == student then
-				table.remove(group.students, i)
+    local group = minetest_classroom.get_group(name)
+    if group then
+        for i = 1, #group.students do
+            if group.students[i] == student then
+                table.remove(group.students, i)
 
-				minetest_classroom.save()
-			end
-		end
-	end
+                minetest_classroom.save()
+            end
+        end
+    end
 end
 
 function minetest_classroom.register_action(name, def)
-	def.name = name
-	_action_by_name[name] = def
-	table.insert(_actions, def)
+    def.name = name
+    _action_by_name[name] = def
+    table.insert(_actions, def)
 end
 
 function minetest_classroom.get_actions()
-	return _actions
+    return _actions
 end
 
 function minetest_classroom.get_students_by_selector(selector)
-	if selector == "*" then
-		return minetest_classroom.get_students()
-	elseif selector:sub(1, 6) == "group:" then
-		return minetest_classroom.get_group_students(selector:sub(7))
-	elseif selector:sub(1, 5) == "user:" then
-		local pname = selector:sub(6)
-		if minetest_classroom.get_player_by_name(pname) then
-			return { pname }
-		else
-			return {}
-		end
-	elseif selector:sub(1,6) == "realm:" then
-		return Realm.GetRealm(selector:sub(7)):GetPlayersAsArray()
-	else
-		return {}
-	end
+    if selector == "*" then
+        return minetest_classroom.get_students()
+    elseif selector:sub(1, 6) == "group:" then
+        return minetest_classroom.get_group_students(selector:sub(7))
+    elseif selector:sub(1, 5) == "user:" then
+        local pname = selector:sub(6)
+        if minetest_classroom.get_player_by_name(pname) then
+            return { pname }
+        else
+            return {}
+        end
+    elseif selector:sub(1, 6) == "realm:" then
+        return Realm.GetRealm(selector:sub(7)):GetPlayersAsArray()
+    else
+        return {}
+    end
 end
 
 function minetest_classroom.run_action(aname, runner, selector, params)
-	local action   = _action_by_name[aname]
-	local students = minetest_classroom.get_students_by_selector(selector)
-	if #students > 0 then
-		action.func(runner, students)
-	end
+    local action = _action_by_name[aname]
+    local students = minetest_classroom.get_students_by_selector(selector)
+    if #students > 0 then
+        action.func(runner, students)
+    end
 end

--- a/mods/mc_teacher/api.lua
+++ b/mods/mc_teacher/api.lua
@@ -150,6 +150,8 @@ function minetest_classroom.get_students_by_selector(selector)
 		else
 			return {}
 		end
+	elseif selector:sub(1,6) == "realm:" then
+		return Realm.GetRealm(selector:sub(7)):GetPlayersAsArray()
 	else
 		return {}
 	end

--- a/mods/mc_teacher/api.lua
+++ b/mods/mc_teacher/api.lua
@@ -33,6 +33,7 @@ function minetest_classroom.get_students()
 end
 
 function minetest_classroom.get_group_students(name)
+	name = mc_helpers.trim(name)
 	local group = minetest_classroom.get_group(name)
 	if not group then
 		return nil
@@ -70,10 +71,12 @@ function minetest_classroom.get_all_groups()
 end
 
 function minetest_classroom.get_group(name)
+	name = mc_helpers.trim(name)
 	return _groups[name]
 end
 
 function minetest_classroom.create_group(name)
+	name = mc_helpers.trim(name)
 	if _groups[name] or #name == 0 then
 		return nil
 	end
@@ -91,6 +94,7 @@ function minetest_classroom.create_group(name)
 end
 
 function minetest_classroom.remove_group(name)
+	name = mc_helpers.trim(name)
 	_groups[name].students = nil
 	_groups[name].name = nil
 	_groups[name] = nil

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -24,7 +24,7 @@ local infos = {
     },
 }
 local tool_name = "mc_teacher:controller"
-local priv_table = {teacher = true}
+local priv_table = { teacher = true }
 
 local function get_group(context)
     if context and context.groupname then
@@ -36,49 +36,49 @@ end
 
 -- Label the teacher in red
 minetest.register_on_joinplayer(function(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         player:set_nametag_attributes({ color = { r = 255, g = 0, b = 0 } })
     end
 end)
 
 -- Define an initial formspec that will redirect to different formspecs depending on what the teacher wants to do
 local mc_teacher_menu = {
-	"formspec_version[5]",
-	"size[10,9]",
-	"label[3.2,0.7;What do you want to do?]",
-	"button[1,1.6;3.8,1.3;spawn;Go to UBC]",
-	"button[5.2,1.6;3.8,1.3;tasks;Manage Tasks]",
-	"button[1,3.3;3.8,1.3;lessons;Manage Lessons]",
-	"button[5.2,3.3;3.8,1.3;players;Manage Players]",
-	"button[1,5;3.8,1.3;classrooms;Manage Classrooms]",
-	"button[5.2,5;3.8,1.3;rules;Manage Server Rules]",
-	"button[1,6.7;3.8,1.3;mail;Teacher Mail]",
-	"button_exit[5.2,6.7;3.8,1.3;exit;Exit]"
+    "formspec_version[5]",
+    "size[10,9]",
+    "label[3.2,0.7;What do you want to do?]",
+    "button[1,1.6;3.8,1.3;spawn;Go to UBC]",
+    "button[5.2,1.6;3.8,1.3;tasks;Manage Tasks]",
+    "button[1,3.3;3.8,1.3;lessons;Manage Lessons]",
+    "button[5.2,3.3;3.8,1.3;players;Manage Players]",
+    "button[1,5;3.8,1.3;classrooms;Manage Classrooms]",
+    "button[5.2,5;3.8,1.3;rules;Manage Server Rules]",
+    "button[1,6.7;3.8,1.3;mail;Teacher Mail]",
+    "button_exit[5.2,6.7;3.8,1.3;exit;Exit]"
 }
 
 local function show_teacher_menu(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
-        minetest.show_formspec(pname, "mc_teacher:menu", table.concat(mc_teacher_menu,""))
+        minetest.show_formspec(pname, "mc_teacher:menu", table.concat(mc_teacher_menu, ""))
         return true
     end
 end
 
 -- Define the Manage Tasks formspec (teacher-view)
 local mc_teacher_tasks = {
-	"formspec_version[5]",
-	"size[10,13]",
-	"field[0.375,0.75;9.25,0.8;task;Enter task below;]",
-	"textarea[0.375,2.5;9.25,7;instructions;Enter instructions below;]",
-	"field[0.375,10.5;9.25,0.8;timer;Enter timer for task in seconds (0 or blank = no timer);]",
-	"button[0.375,11.5;2,0.8;back;Back]",
-	"button_exit[2.575,11.5;2,0.8;submit;Submit]"
+    "formspec_version[5]",
+    "size[10,13]",
+    "field[0.375,0.75;9.25,0.8;task;Enter task below;]",
+    "textarea[0.375,2.5;9.25,7;instructions;Enter instructions below;]",
+    "field[0.375,10.5;9.25,0.8;timer;Enter timer for task in seconds (0 or blank = no timer);]",
+    "button[0.375,11.5;2,0.8;back;Back]",
+    "button_exit[2.575,11.5;2,0.8;submit;Submit]"
 }
 
 local function show_tasks(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
-        minetest.show_formspec(pname, "mc_teacher:tasks", table.concat(mc_teacher_tasks,""))
+        minetest.show_formspec(pname, "mc_teacher:tasks", table.concat(mc_teacher_tasks, ""))
         return true
     end
 end
@@ -129,13 +129,15 @@ end
 local DASHBOARD_HEADER = "formspec_version[5]size[13,11]"
 
 local function get_player_list_formspec(player, context)
-    if not mc_helpers.checkPrivs(player,priv_table) then
+    if not mc_helpers.checkPrivs(player, priv_table) then
         return "label[0,0;" .. FS "Access denied" .. "]"
     end
 
     if context.selected_student and not minetest.get_player_by_name(context.selected_student) then
         context.selected_student = nil
     end
+
+    context.realm = Realm.GetRealmFromPlayer(player).ID
 
     local function button(def)
         local x = assert(def.x)
@@ -304,7 +306,7 @@ local function get_player_list_formspec(player, context)
     do
         local btn = {
             x = 8.5, y = 2,
-            w = 1.4, h = 0.8,
+            w = 1, h = 0.8,
             name = "select_group",
             text = FS "Group",
         }
@@ -324,8 +326,8 @@ local function get_player_list_formspec(player, context)
     -- Select Selected button
     do
         local btn = {
-            x = 10, y = 2,
-            w = 1.8, h = 0.8,
+            x = 9.7, y = 2,
+            w = 1, h = 0.8,
             name = "select_selected",
             text = FS "Selected",
         }
@@ -335,6 +337,28 @@ local function get_player_list_formspec(player, context)
             btn.tooltip = FS "Please select a student first"
         elseif context.select_toggle == "selected" then
             btn.state = "selected"
+        else
+            btn.state = "active"
+        end
+
+        fs[#fs + 1] = button(btn)
+    end
+
+    -- Select Realm button
+    do
+        local btn = {
+            x = 10.9, y = 2,
+            w = 1, h = 0.8,
+            name = "select_realm",
+            text = FS "Realm",
+        }
+
+        if not context.realm then
+            btn.state = "disabled"
+            btn.tooltip = FS "Please ensure that you're not at spawn first."
+        elseif context.select_toggle == "realm" then
+            btn.state = "selected"
+            btn.tooltip = FS "You are in realm: " .. context.realm
         else
             btn.state = "active"
         end
@@ -366,7 +390,7 @@ local function get_player_list_formspec(player, context)
 end
 
 local function handle_results(player, context, fields)
-    if not mc_helpers.checkPrivs(player,priv_table) then
+    if not mc_helpers.checkPrivs(player, priv_table) then
         return false
     end
 
@@ -404,6 +428,9 @@ local function handle_results(player, context, fields)
     elseif fields.select_selected then
         context.select_toggle = "selected"
         return true
+    elseif fields.select_realm then
+        context.select_toggle = "realm"
+        return true
     end
 
     if fields.teleport and context.selected_student then
@@ -436,6 +463,8 @@ local function handle_results(player, context, fields)
                 selector = "group:" .. context.groupname
             elseif context.select_toggle == "selected" then
                 selector = "user:" .. context.selected_student
+            elseif context.select_toggle == "realm" then
+                selector = "realm:" .. context.realm
             else
                 error("Unknown selector")
             end
@@ -448,7 +477,7 @@ end
 
 local _contexts = {}
 local function show_players(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
         local context = _contexts[pname] or {}
         _contexts[pname] = context
@@ -462,7 +491,7 @@ end
 local mc_teacher_lessons = "formspec_version[5]"
 
 local function show_lessons(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
         minetest.show_formspec(pname, "mc_teacher:lessons", mc_teacher_lessons)
         return true
@@ -471,13 +500,13 @@ end
 
 -- Define the Manage Classrooms formspec
 local function show_classrooms(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
-        local mc_teacher_classrooms = { 
-                "formspec_version[5]",
-                "size[14,14]",
-                "label[0.4,0.8;Your Classrooms]",
-                "button[0.375,6.5;4,0.8;join;Join Selected Classroom]",
-                "button[0.375,7.5;4,0.8;delete;Delete Selected Classroom]"
+    if mc_helpers.checkPrivs(player, priv_table) then
+        local mc_teacher_classrooms = {
+            "formspec_version[5]",
+            "size[14,14]",
+            "label[0.4,0.8;Your Classrooms]",
+            "button[0.375,6.5;4,0.8;join;Join Selected Classroom]",
+            "button[0.375,7.5;4,0.8;delete;Delete Selected Classroom]"
         }
 
         -- Get the stored classrooms for the teacher
@@ -509,11 +538,11 @@ local function show_classrooms(player)
             for i in pairs(pcc) do
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = pcc[i]
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = " "
-                mc_teacher_classrooms[#mc_teacher_classrooms + 1] =  psn[i]
+                mc_teacher_classrooms[#mc_teacher_classrooms + 1] = psn[i]
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = " "
-                mc_teacher_classrooms[#mc_teacher_classrooms + 1] =  map[i]
+                mc_teacher_classrooms[#mc_teacher_classrooms + 1] = map[i]
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = " Expires "
-                mc_teacher_classrooms[#mc_teacher_classrooms + 1] = pem[i] 
+                mc_teacher_classrooms[#mc_teacher_classrooms + 1] = pem[i]
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = " "
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = ped[i]
                 mc_teacher_classrooms[#mc_teacher_classrooms + 1] = " "
@@ -546,7 +575,7 @@ local function show_classrooms(player)
         mc_teacher_classrooms[#mc_teacher_classrooms + 1] = "button[9.625,13;4,0.8;submit;Create New Classroom]"
         mc_teacher_classrooms[#mc_teacher_classrooms + 1] = "button[0.375,13;2,0.8;back;Back]"
         mc_teacher_classrooms[#mc_teacher_classrooms + 1] = "button[2.575,13;2,0.8;deleteall;Delete All]"
-        
+
         local pname = player:get_player_name()
         minetest.show_formspec(pname, "mc_teacher:classrooms", table.concat(mc_teacher_classrooms, ""))
         return true
@@ -564,7 +593,7 @@ local function get_reports_formspec(reports)
     -- Add the reports
     local reports_table = minetest_classroom.reports:to_table()["fields"]
     for k, v in pairs(reports_table) do
-        mc_teacher_mail[#mc_teacher_mail + 1] = k 
+        mc_teacher_mail[#mc_teacher_mail + 1] = k
         mc_teacher_mail[#mc_teacher_mail + 1] = " "
         mc_teacher_mail[#mc_teacher_mail + 1] = v
         mc_teacher_mail[#mc_teacher_mail + 1] = ","
@@ -576,7 +605,7 @@ local function get_reports_formspec(reports)
 end
 
 local function show_mail(player)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
         minetest.show_formspec(pname, "mc_teacher:mail", get_reports_formspec(minetest_classroom.reports))
         return true
@@ -588,7 +617,7 @@ end
 
 -- Processing the form from the menu
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-    if string.sub(formname, 1, 10) ~= "mc_teacher" or not mc_helpers.checkPrivs(player,priv_table) then
+    if string.sub(formname, 1, 10) ~= "mc_teacher" or not mc_helpers.checkPrivs(player, priv_table) then
         return false
     end
 
@@ -601,15 +630,15 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
     -- Menu
     if formname == "mc_teacher:menu" then
         if fields.spawn then
-	    -- Temporary patch to stop server from crashing
+            -- Temporary patch to stop server from crashing
             --local spawnRealm = mc_worldManager.GetSpawnRealm()
             --spawnRealm:TeleportPlayer(player)
             local spawn_pos = {
-            	x = 1426,
-            	y = 92,
-            	z = 1083,
-             }
-             player:set_pos(spawn_pos)		
+                x = 1426,
+                y = 92,
+                z = 1083,
+            }
+            player:set_pos(spawn_pos)
         elseif fields.tasks then
             show_tasks(player)
         elseif fields.lessons then
@@ -805,7 +834,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 end)
 
 function record_classroom(player, cc, sn, sy, sm, sd, ey, em, ed, map)
-    if mc_helpers.checkPrivs(player,priv_table) then
+    if mc_helpers.checkPrivs(player, priv_table) then
         local pname = player:get_player_name()
         pmeta = player:get_meta()
 
@@ -816,10 +845,7 @@ function record_classroom(player, cc, sn, sy, sm, sd, ey, em, ed, map)
         math.randomseed(os.time())
         access_num = tostring(math.floor(math.random() * 100000))
 
-
-        local newRealm = Realm:NewFromSchematic(cc..sn..map, map)
-
-
+        local newRealm = Realm:NewFromSchematic(cc .. sn .. map, map)
 
         if temp == nil then
             -- Build the new classroom table entry
@@ -904,7 +930,7 @@ minetest.register_tool(tool_name, {
     on_use = function(itemstack, player, pointed_thing)
         local pname = player:get_player_name()
         -- Check for teacher privileges
-        if mc_helpers.checkPrivs(player,priv_table) then
+        if mc_helpers.checkPrivs(player, priv_table) then
             show_teacher_menu(player)
         end
     end,

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -353,12 +353,11 @@ local function get_player_list_formspec(player, context)
             text = FS "Realm",
         }
 
-        if not context.realm then
+        if context.realm == mc_worldManager.GetSpawnRealm().ID then
             btn.state = "disabled"
             btn.tooltip = FS "Please ensure that you're not at spawn first."
         elseif context.select_toggle == "realm" then
             btn.state = "selected"
-            btn.tooltip = FS "You are in realm: " .. context.realm
         else
             btn.state = "active"
         end

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -195,7 +195,7 @@ local function get_player_list_formspec(player, context)
         "tablecolumns[color;text",
     }
 
-    context.select_toggle = context.select_toggle or "all"
+    context.select_toggle = context.select_toggle or "realm"
 
     for i, col in pairs(infos) do
         fs[#fs + 1] = ";color;text,align=center"
@@ -208,6 +208,7 @@ local function get_player_list_formspec(player, context)
     do
         fs[#fs + 1] = "tabheader[0,0;6.7,0.8;group;"
         fs[#fs + 1] = FS "All"
+
         local selected_group_idx = 1
         local i = 2
         for name, group in pairs(minetest_classroom.get_all_groups()) do
@@ -353,10 +354,7 @@ local function get_player_list_formspec(player, context)
             text = FS "Realm",
         }
 
-        if context.realm == mc_worldManager.GetSpawnRealm().ID then
-            btn.state = "disabled"
-            btn.tooltip = FS "Please ensure that you're not at spawn first."
-        elseif context.select_toggle == "realm" then
+        if context.select_toggle == "realm" then
             btn.state = "selected"
         else
             btn.state = "active"

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -818,6 +818,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
                 pdata.end_day[context.selected] = nil
                 pdata.classroom_map[context.selected] = nil
                 pdata.access_code[context.selected] = nil
+                pdata.realm_id[context.selected] = nil
                 pmeta:set_string("classrooms", minetest.serialize(pdata
                 ))
 

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -217,7 +217,7 @@ local function get_player_list_formspec(player, context)
         local selected_group_idx = 1
         local i = 2
 
-        for name, group in pairs(minetest_classroom.get_all_groups(player)) do
+        for name, group in pairs(minetest_classroom.get_all_groups()) do
             fs[#fs + 1] = ","
             fs[#fs + 1] = minetest.formspec_escape(name)
             if context.groupname and name == context.groupname then

--- a/mods/mc_teacher/gui_dash.lua
+++ b/mods/mc_teacher/gui_dash.lua
@@ -28,7 +28,12 @@ local priv_table = { teacher = true }
 
 local function get_group(context)
     if context and context.groupname then
-        return minetest_classroom.get_group_students(context.groupname)
+        if (context.groupname == "Realm") then
+            return minetest_classroom.get_realm_students(context.realm)
+        else
+            return minetest_classroom.get_group_students(context.groupname)
+        end
+
     else
         return minetest_classroom.get_students()
     end
@@ -211,7 +216,8 @@ local function get_player_list_formspec(player, context)
 
         local selected_group_idx = 1
         local i = 2
-        for name, group in pairs(minetest_classroom.get_all_groups()) do
+
+        for name, group in pairs(minetest_classroom.get_all_groups(player)) do
             fs[#fs + 1] = ","
             fs[#fs + 1] = minetest.formspec_escape(name)
             if context.groupname and name == context.groupname then
@@ -259,6 +265,8 @@ local function get_player_list_formspec(player, context)
     fs[#fs + 1] = "]"
     fs[#fs + 1] = "container_end[]"
 
+
+
     -- New Group button
     do
         local btn = {
@@ -278,7 +286,7 @@ local function get_player_list_formspec(player, context)
             w = 2.5, h = 0.8,
             name = "edit_group",
             text = FS "Edit Group",
-            state = context.groupname ~= nil,
+            state = context.groupname ~= nil and context.groupname ~= "Realm",
             tooltip = not context.groupname and FS "Please select a group first",
         }
 
@@ -312,7 +320,7 @@ local function get_player_list_formspec(player, context)
             text = FS "Group",
         }
 
-        if not context.groupname then
+        if (context.groupname == nil or context.groupname == "Realm") then
             btn.state = "disabled"
             btn.tooltip = FS "Please select a group first"
         elseif context.select_toggle == "group" then

--- a/mods/mc_teacher/init.lua
+++ b/mods/mc_teacher/init.lua
@@ -42,3 +42,19 @@ schematicManager.registerSchematicPath("MKRF512_hillshade", minetest.get_modpath
 schematicManager.registerSchematicPath("MKRF512_slope", minetest.get_modpath("mc_teacher") .. "/maps/MKRF512_slope")
 schematicManager.registerSchematicPath("MKRF512_tpi", minetest.get_modpath("mc_teacher") .. "/maps/MKRF512_tpi")
 
+Realm.RegisterOnCreateCallback(function(realm)
+    minetest_classroom.create_group(realm.Name)
+end)
+
+Realm.RegisterOnLeaveCallback(function(realm)
+    minetest_classroom.remove_group(realm.Name)
+end)
+
+Realm.RegisterOnJoinCallback(function(realm, player)
+    minetest_classroom.add_student_to_group(realm.Name, player.get_player_by_name())
+end)
+
+Realm.RegisterOnLeaveCallback(function(realm, player)
+    minetest_classroom.remove_student_from_group(realm.Name, player.get_player_by_name())
+end)
+

--- a/mods/mc_teacher/init.lua
+++ b/mods/mc_teacher/init.lua
@@ -42,6 +42,8 @@ schematicManager.registerSchematicPath("MKRF512_hillshade", minetest.get_modpath
 schematicManager.registerSchematicPath("MKRF512_slope", minetest.get_modpath("mc_teacher") .. "/maps/MKRF512_slope")
 schematicManager.registerSchematicPath("MKRF512_tpi", minetest.get_modpath("mc_teacher") .. "/maps/MKRF512_tpi")
 
+
+--[[
 Realm.RegisterOnCreateCallback(function(realm)
     minetest_classroom.create_group(realm.Name)
 end)
@@ -57,4 +59,4 @@ end)
 Realm.RegisterOnLeaveCallback(function(realm, player)
     minetest_classroom.remove_student_from_group(realm.Name .. " Realm Group", player:get_player_name())
 end)
-
+--]]

--- a/mods/mc_teacher/init.lua
+++ b/mods/mc_teacher/init.lua
@@ -51,10 +51,10 @@ Realm.RegisterOnLeaveCallback(function(realm)
 end)
 
 Realm.RegisterOnJoinCallback(function(realm, player)
-    minetest_classroom.add_student_to_group(realm.Name, player:get_player_name())
+    minetest_classroom.add_student_to_group(realm.Name .. " Realm Group", player:get_player_name())
 end)
 
 Realm.RegisterOnLeaveCallback(function(realm, player)
-    minetest_classroom.remove_student_from_group(realm.Name, player:get_player_name())
+    minetest_classroom.remove_student_from_group(realm.Name .. " Realm Group", player:get_player_name())
 end)
 

--- a/mods/mc_teacher/init.lua
+++ b/mods/mc_teacher/init.lua
@@ -51,10 +51,10 @@ Realm.RegisterOnLeaveCallback(function(realm)
 end)
 
 Realm.RegisterOnJoinCallback(function(realm, player)
-    minetest_classroom.add_student_to_group(realm.Name, player.get_player_by_name())
+    minetest_classroom.add_student_to_group(realm.Name, player:get_player_name())
 end)
 
 Realm.RegisterOnLeaveCallback(function(realm, player)
-    minetest_classroom.remove_student_from_group(realm.Name, player.get_player_by_name())
+    minetest_classroom.remove_student_from_group(realm.Name, player:get_player_name())
 end)
 

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -39,7 +39,7 @@ commands["new"] = {
 commands["delete"] = {
     func = function(name, params)
         local realmID = params[1]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end
@@ -59,7 +59,7 @@ commands["list"] = {
 commands["info"] = {
     func = function(name, params)
         local realmID = params[1]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm does not exist."
         end
@@ -80,7 +80,7 @@ commands["tp"] = {
     privs = { teleport = true },
     func = function(name, params)
         local realmID = params[1]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end
@@ -94,7 +94,7 @@ commands["tp"] = {
 commands["walls"] = {
     func = function(name, params)
         local realmID = params[1]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end
@@ -115,7 +115,7 @@ commands["schematic"] = {
         elseif (params[1] == "save") then
             table.remove(params, 1)
             local realmID = params[1]
-            local requestedRealm = Realm.realmDict[tonumber(realmID)]
+            local requestedRealm = Realm.GetRealm(tonumber(realmID))
 
             if (requestedRealm == nil) then
                 return false, "Requested realm of ID:" .. realmID .. " does not exist."
@@ -170,7 +170,7 @@ commands["setspawn"] = {
 commands["setspawnrealm"] = {
     func = function(name, params)
         local realmID = params[1]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end
@@ -239,7 +239,7 @@ commands["define"] = {
 commands["players"] = {
     func = function(name, params)
         local realmID = params[2]
-        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -24,7 +24,7 @@ minetest.register_chatcommand("localPos", {
 commands["new"] = {
     func = function(name, params)
         local realmName = tostring(params[1])
-        if (realmName == "" or realmName == nil) then
+        if (realmName == "" or realmName == "nil") then
             realmName = "Unnamed Realm"
         end
         local sizeX = tonumber(params[2])

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -238,13 +238,15 @@ commands["define"] = {
 
 commands["players"] = {
     func = function(name, params)
-        local realmID = params[2]
-        local requestedRealm = Realm.GetRealm(tonumber(realmID))
-        if (requestedRealm == nil) then
-            return false, "Requested realm of ID:" .. realmID .. " does not exist."
-        end
+
 
         if (params[1] == "list") then
+            local realmID = params[2]
+            local requestedRealm = Realm.GetRealm(tonumber(realmID))
+            if (requestedRealm == nil) then
+                return false, "Requested realm of ID:" .. realmID .. " does not exist."
+            end
+
             local realmPlayerList = requestedRealm:get_tmpData("Inhabitants")
 
             if (realmPlayerList == nil) then
@@ -253,12 +255,15 @@ commands["players"] = {
 
             Debug.log(minetest.serialize(realmPlayerList))
 
-
             for k, v in pairs(realmPlayerList) do
                 minetest.chat_send_player(name, k)
             end
 
             return true, "listed all players in realm."
+        elseif (params[1] == "scan") then
+            Realm.ScanForPlayerRealms()
+            return true, "re-associated players with realms."
+
         end
 
         return false, "unknown sub-command."

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -9,8 +9,6 @@ minetest.register_chatcommand("localPos", {
         teacher = true,
     },
     func = function(name, param)
-
-
         local player = minetest.get_player_by_name(name)
 
         local pmeta = player:get_meta()
@@ -91,7 +89,7 @@ commands["tp"] = {
             return false, "Requested realm of ID:" .. realmID .. " does not exist."
         end
 
-        player = minetest.get_player_by_name(name)
+        local player = minetest.get_player_by_name(name)
         requestedRealm:TeleportPlayer(player)
 
         return true, "teleported to: " .. realmID
@@ -209,8 +207,6 @@ commands["help"] = {
 
 commands["define"] = {
     func = function(name, params)
-        local params = mc_helpers.split(param, " ")
-
         -- this is really hacky, we should come up with a better way to do this...
 
         local name = tostring(params[1])
@@ -244,6 +240,35 @@ commands["define"] = {
         Realm.realmCount = newRealm.ID
         Realm:Restore(newRealm)
     end }
+
+commands["players"] = {
+    func = function(name, params)
+        local realmID = params[2]
+        local requestedRealm = Realm.realmDict[tonumber(realmID)]
+        if (requestedRealm == nil) then
+            return false, "Requested realm of ID:" .. realmID .. " does not exist."
+        end
+
+        if (params[1] == "list") then
+            local realmPlayerList = requestedRealm:get_tmpData("Inhabitants")
+
+            if (realmPlayerList == nil) then
+                return false, "no players found in realm player list."
+            end
+
+            Debug.log(minetest.serialize(realmPlayerList))
+
+
+            for k, v in pairs(realmPlayerList) do
+                minetest.chat_send_player(name, k)
+            end
+
+            return true, "listed all players in realm."
+        end
+
+        return false, "unknown sub-command."
+    end
+}
 
 minetest.register_chatcommand("realm", {
     params = "Subcommand Realm ID Option",

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -10,11 +10,7 @@ minetest.register_chatcommand("localPos", {
     },
     func = function(name, param)
         local player = minetest.get_player_by_name(name)
-
-        local pmeta = player:get_meta()
-        local realmID = pmeta:get_int("realm")
-
-        local requestedRealm = Realm.realmDict[realmID]
+        local requestedRealm = Realm.GetRealmFromPlayer(player)
 
         if (requestedRealm == nil) then
             return false, "Player is not listed in a realm OR current realm has been deleted; Try teleporting to a different realm and then back..."
@@ -161,15 +157,14 @@ commands["schematic"] = {
 commands["setspawn"] = {
     func = function(name, params)
         local player = minetest.get_player_by_name(name)
-        local pmeta = player:get_meta()
-        local realmID = pmeta:get_int("realm")
-        local requestedRealm = Realm.realmDict[realmID]
+
+        local requestedRealm = Realm.GetRealmFromPlayer(player)
 
         local position = requestedRealm:WorldToLocalPosition(player:get_pos())
 
         requestedRealm:UpdateSpawn(position)
 
-        return true, "Updated spawnpoint for realm with ID: " .. realmID
+        return true, "Updated spawnpoint for realm with ID: " .. requestedRealm.ID
     end }
 
 commands["setspawnrealm"] = {

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -23,13 +23,14 @@ minetest.register_chatcommand("localPos", {
 
 commands["new"] = {
     func = function(name, params)
-        local realmName = params[2]
+        local realmName = tostring(params[1])
         if (realmName == "" or realmName == nil) then
             realmName = "Unnamed Realm"
         end
-        local size = params[3]
-        local sizeY = params[4]
-        local newRealm = Realm:New(realmName, { x = size, y = sizeY, z = size })
+        local sizeX = tonumber(params[2]) or 40
+        local sizeY = tonumber(params[3]) or 40
+        local sizeZ = tonumber(params[4]) or 40
+        local newRealm = Realm:New(realmName, { x = sizeX, y = sizeY, z = sizeZ })
         newRealm:CreateGround()
         newRealm:CreateBarriers()
 
@@ -39,6 +40,11 @@ commands["new"] = {
 commands["delete"] = {
     func = function(name, params)
         local realmID = params[1]
+
+        if (realmID == nil) then
+            return false, "No realm ID specified"
+        end
+
         local requestedRealm = Realm.GetRealm(tonumber(realmID))
         if (requestedRealm == nil) then
             return false, "Requested realm of ID:" .. realmID .. " does not exist."

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -27,9 +27,18 @@ commands["new"] = {
         if (realmName == "" or realmName == nil) then
             realmName = "Unnamed Realm"
         end
-        local sizeX = tonumber(params[2]) or 40
-        local sizeY = tonumber(params[3]) or 40
+        local sizeX = tonumber(params[2])
+        if (sizeX == nil or sizeX == 0) then
+            sizeX = 40
+        end
+        local sizeY = tonumber(params[3])
+        if (sizeY == nil or sizeY == 0) then
+            sizeY = 40
+        end
         local sizeZ = tonumber(params[4]) or 40
+        if (SizeZ == nil or SizeZ == 0) then
+            SizeZ = 40
+        end
         local newRealm = Realm:New(realmName, { x = sizeX, y = sizeY, z = sizeZ })
         newRealm:CreateGround()
         newRealm:CreateBarriers()
@@ -43,6 +52,10 @@ commands["delete"] = {
 
         if (realmID == nil) then
             return false, "No realm ID specified"
+        end
+
+        if (realmID == mc_worldManager.spawnRealmID) then
+            return false, "Cannot delete the spawn realm."
         end
 
         local requestedRealm = Realm.GetRealm(tonumber(realmID))

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -3,11 +3,7 @@
 minetest.register_on_newplayer(function(player)
 
     local spawnRealm = mc_worldManager.GetSpawnRealm()
-
-    local pmeta = player:get_meta()
-    pmeta:set_int("realm", spawnRealm.ID)
-
-    player:set_pos(spawnRealm.SpawnPoint)
+    spawnRealm:TeleportPlayer(player)
 end)
 
 -- When players respawn, we teleport them to the spawnpoint of the realm they belong to

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -24,7 +24,7 @@ minetest.register_on_joinplayer(function(player, last_login)
 
     local realm = Realm.GetRealmFromPlayer(player)
     if (realm ~= nil) then
-        realm:AddPlayer(player)
+        realm:RegisterPlayer(player)
     end
 
 end)
@@ -35,7 +35,7 @@ minetest.register_on_leaveplayer(function(player, timed_out)
 
     local realm = Realm.GetRealmFromPlayer(player)
     if (realm ~= nil) then
-        realm:RemovePlayer(player)
+        realm:DeregisterPlayer(player)
     end
 
 end)

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -14,7 +14,7 @@ minetest.register_on_respawnplayer(function(player)
     else
         player:set_pos(mc_worldManager.GetSpawnRealm().SpawnPoint)
     end
-    
+
     return true
 end)
 
@@ -29,7 +29,7 @@ minetest.register_on_joinplayer(function(player, last_login)
 
 end)
 
--- When player leave the game, we create their hud
+-- When player leave the game, we delete their hud
 minetest.register_on_leaveplayer(function(player, timed_out)
     mc_worldManager.RemoveHud(player)
 

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -1,7 +1,6 @@
 -- on first player spawn, we assign them to the world spawn realm
 -- and set their position to that spawnpoint .
 minetest.register_on_newplayer(function(player)
-
     local spawnRealm = mc_worldManager.GetSpawnRealm()
     spawnRealm:TeleportPlayer(player)
 end)
@@ -12,7 +11,7 @@ minetest.register_on_respawnplayer(function(player)
     local pmeta = player:get_meta()
     local playerRealmID = pmeta:get_int("realm")
 
-    local spawnRealm
+    local spawnRealm = nil
 
     if (playerRealmID ~= nil) then
         spawnRealm = Realm.realmDict[playerRealmID]

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -7,28 +7,39 @@ end)
 
 -- When players respawn, we teleport them to the spawnpoint of the realm they belong to
 minetest.register_on_respawnplayer(function(player)
+    local realm = Realm.GetRealmFromPlayer(player)
 
-    local pmeta = player:get_meta()
-    local playerRealmID = pmeta:get_int("realm")
-
-    local spawnRealm = nil
-
-    if (playerRealmID ~= nil) then
-        spawnRealm = Realm.realmDict[playerRealmID]
+    if (realm ~= nil) then
+        player:set_pos(realm.SpawnPoint)
     else
-        spawnRealm = mc_worldManager.GetSpawnRealm()
+        player:set_pos(mc_worldManager.GetSpawnRealm().SpawnPoint)
     end
-
-    player:set_pos(spawnRealm.SpawnPoint)
+    
     return true
 end)
 
 -- When player joins the game, we create their hud
 minetest.register_on_joinplayer(function(player, last_login)
     mc_worldManager.CreateHud(player)
+
+    local realm = Realm.GetRealmFromPlayer(player)
+    if (realm ~= nil) then
+        realm:AddPlayer(player)
+    end
+
 end)
 
 -- When player leave the game, we create their hud
 minetest.register_on_leaveplayer(function(player, timed_out)
     mc_worldManager.RemoveHud(player)
+
+    local realm = Realm.GetRealmFromPlayer(player)
+    if (realm ~= nil) then
+        realm:RemovePlayer(player)
+    end
+
+end)
+
+minetest.register_on_shutdown(function()
+    Realm.SaveDataToStorage()
 end)

--- a/mods/mc_worldmanager/hud.lua
+++ b/mods/mc_worldmanager/hud.lua
@@ -25,7 +25,9 @@ function mc_worldManager.CreateHud(player)
 end
 
 function mc_worldManager.updateHud(player)
-
+    if (not mc_worldManager.hud:exists(player, "worldManager:currentRealm")) then
+        return false
+    end
     mc_worldManager.hud:change(player, "worldManager:currentRealm", {
         hud_elem_type = "text",
         position = { x = 1, y = 0 },
@@ -34,6 +36,8 @@ function mc_worldManager.updateHud(player)
         text = createHudString(player),
         color = 0xFFFFFF,
     })
+
+    return true
 end
 
 function mc_worldManager.RemoveHud(player)

--- a/mods/mc_worldmanager/hud.lua
+++ b/mods/mc_worldmanager/hud.lua
@@ -1,19 +1,14 @@
 local function createHudString(player)
-    local pmeta = player:get_meta()
-    local realmID = pmeta:get_int("realm")
-    local realm = Realm.realmDict[realmID]
-
-    local string = "Realm " .. realmID
-
+    local realm = Realm.GetRealmFromPlayer(player)
+    local string = "Realm "
     if (realm ~= nil) then
+        string = string .. realm.ID
         string = string .. " : " .. realm.Name
     end
     return string
 end
 
 function mc_worldManager.CreateHud(player)
-
-
     mc_worldManager.hud:add(player, "worldManager:currentRealm", {
         hud_elem_type = "text",
         position = { x = 1, y = 0 },

--- a/mods/mc_worldmanager/init.lua
+++ b/mods/mc_worldmanager/init.lua
@@ -34,7 +34,7 @@ function mc_worldManager.GetSpawnRealm()
     local spawnRealm = Realm.realmDict[mc_worldManager.spawnRealmID]
     if (spawnRealm == nil) then
 
-        spawnRealm = Realm:NewFromSchematic("Spawn Realm", mc_worldManager.spawnRealmSchematic)
+        spawnRealm = Realm:NewFromSchematic("Spawn", mc_worldManager.spawnRealmSchematic)
         mc_worldManager.spawnRealmID = spawnRealm.ID
         mc_worldManager.save_data()
         Debug.log("Saving spawn realm information")

--- a/mods/mc_worldmanager/init.lua
+++ b/mods/mc_worldmanager/init.lua
@@ -31,9 +31,8 @@ mc_worldManager.load_data()
 ---This function ensures that systems that rely on a spawn don't break.
 ---@return table Realm
 function mc_worldManager.GetSpawnRealm()
-    local spawnRealm = Realm.realmDict[mc_worldManager.spawnRealmID]
+    local spawnRealm = Realm.GetRealm(mc_worldManager.spawnRealmID)
     if (spawnRealm == nil) then
-
         spawnRealm = Realm:NewFromSchematic("Spawn", mc_worldManager.spawnRealmSchematic)
         mc_worldManager.spawnRealmID = spawnRealm.ID
         mc_worldManager.save_data()
@@ -47,7 +46,6 @@ end
 ---@param newSpawnRealm table realm to set as spawn.
 ---@return boolean whether the operation succeeded or not.
 function mc_worldManager.SetSpawnRealm(newSpawnRealm)
-
     if (newSpawnRealm ~= nil) then
         mc_worldManager.spawnRealmID = newSpawnRealm.ID
         mc_worldManager.save_data()

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -79,6 +79,13 @@ function Realm:New(name, area)
     return this
 end
 
+---GetRealm
+---@param ID number
+---Returns the realm corresponding to the ID parameter.
+function Realm.GetRealm(ID)
+    return Realm.realmDict[ID]
+end
+
 -- Online bin packing... A pretty challenging problem to solve.
 -- To simplify the problem, we'll create new bins for each new realm we make.
 -- When we need to create new realms, we'll run the bin packing algorithm

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -33,9 +33,18 @@ end
 ---@param area table Size of the realm in {x,y,z} format
 ---@return table a new "Realm" table object / class.
 function Realm:New(name, area)
-    area.x = area.x or 80
-    area.y = area.y or 80
-    area.z = area.z or 80
+
+    if (area.x == nil or area.x == 0) then
+        area.x = 80
+    end
+
+    if (area.y == nil or area.y == 0) then
+        area.y = 80
+    end
+
+    if (area.z == nil or area.z == 0) then
+        area.z = 80
+    end
 
     if (name == nil or name == "") then
         name = "Unnamed Realm"
@@ -200,8 +209,19 @@ function Realm.CalculateStartEndPosition(areaInBlocks)
 end
 
 function Realm.markSpaceAsFree(startPos, endPos)
+    Debug.logCoords(startPos, "start pos")
+    Debug.logCoords(endPos, "end pos")
+
+    -- Crashes on a value of 3 when deleting spawns, but only when deleting spawns. I don't know why.
+    -- The values in the calling function 'Delete' are all correct.
+    -- Somehow, the value is turning from '3' to nil between method calls.
+    if (endPos.z == nil) then
+        endPos.z = startPos.z
+        Debug.log("endPos.z is nil")
+    end
+
     local entry = {}
-    entry.startPos = startPos
+    entry.startPos = { x = startPos.x, y = startPos.y, z = startPos.z }
     entry.area = { x = endPos.x - startPos.x,
                    y = endPos.y - startPos.y,
                    z = endPos.z - startPos.z }
@@ -383,11 +403,37 @@ end
 ---NOTE: remember to clear any references to the realm so that memory can be released by the GC.
 ---@return void
 function Realm:Delete()
+
+    -- We need to first calculate where the realm is located on the realm grid.
+    -- For some reason, this code sometimes does not work later on in the process...
+    local gridStartPos = Realm.worldToGridSpace({
+        x = self.StartPos.x,
+        y = self.StartPos.y,
+        z = self.StartPos.z })
+
+    local gridEndPos = Realm.worldToGridSpace({
+        x = self.EndPos.x,
+        y = self.EndPos.y,
+        z = self.EndPos.z })
+
+    gridStartPos.x = gridStartPos.x - Realm.const.bufferSize
+    gridStartPos.y = gridStartPos.y - Realm.const.bufferSize
+    gridStartPos.z = gridStartPos.z - Realm.const.bufferSize
+
+    if (self.ID == mc_worldManager.spawnRealmID) then
+        mc_worldManager.spawnRealmID = nil
+    end
+
+    local players = self:GetPlayers()
+
+    -- We call the functions registered with the realm's OnDelete event as well as global onDelete callbacks.
+
     self:RunFunctionFromTable(self.RealmDeleteTable)
     self:CallOnDeleteCallbacks()
 
+
+    -- We need to remove all players from the realm
     local spawn = mc_worldManager.GetSpawnRealm()
-    local players = self:GetPlayers()
     if (players ~= nil) then
         for k, v in pairs(players) do
             if v == true then
@@ -396,8 +442,11 @@ function Realm:Delete()
         end
     end
 
+
+    -- We clear all nodes from the realm.
     self:ClearNodes()
 
+    -- We clear block protection
     if (areas) then
         local protectionID = self:get_data("protectionID")
         if (protectionID ~= nil) then
@@ -406,17 +455,15 @@ function Realm:Delete()
         end
     end
 
-    local gridSpace = Realm.worldToGridSpace({
-        x = self.StartPos.x,
-        y = self.StartPos.y,
-        z = self.StartPos.z })
+    -- We save the realms data to storage twice. The first time is to ensure that critical data such as the realm dict is saved to disk.
+    -- The second time is to ensure that we have saved the updated realm grid.
 
-    gridSpace.x = gridSpace.x - Realm.const.bufferSize
-    gridSpace.y = gridSpace.y - Realm.const.bufferSize
-    gridSpace.z = gridSpace.z - Realm.const.bufferSize
-
-    Realm.markSpaceAsFree(gridSpace, Realm.worldToGridSpace(self.EndPos))
+    -- remove the realm dictionary entry.
     Realm.realmDict[self.ID] = nil
+    Realm.SaveDataToStorage()
+
+    -- We need to remove the realm from the realm grid and clear the space for other realms.
+    Realm.markSpaceAsFree(gridStartPos, gridEndPos)
     Realm.SaveDataToStorage()
 end
 

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -21,6 +21,8 @@ dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmDataManagement.lu
 dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmSchematicSaveLoad.lua")
 dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmPlayerManagement.lua")
 dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmCoordinateConversion.lua")
+dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmIntegrationHelpers.lua")
+
 if (areas) then
     dofile(minetest.get_modpath("mc_worldmanager") .. "/realm/realmAreasIntegration.lua")
 end
@@ -75,6 +77,8 @@ function Realm:New(name, area)
     end
 
     Realm.SaveDataToStorage()
+
+    this:CallOnCreateCallbacks()
 
     return this
 end
@@ -380,6 +384,7 @@ end
 ---@return void
 function Realm:Delete()
     self:RunFunctionFromTable(self.RealmDeleteTable)
+    self:CallOnDeleteCallbacks()
     self:ClearNodes()
 
     if (areas) then

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -70,7 +70,7 @@ function Realm:New(name, area)
 
     if (areas) then
         local protectionID = areas:add("Server", this.ID .. this.Name, this.StartPos, this.EndPos)
-        this:set_string("protectionID", protectionID)
+        this:set_data("protectionID", protectionID)
         areas:save()
     end
 
@@ -376,7 +376,7 @@ function Realm:Delete()
     self:ClearNodes()
 
     if (areas) then
-        local protectionID = self:get_string("protectionID")
+        local protectionID = self:get_data("protectionID")
         if (protectionID ~= nil) then
             areas:remove(protectionID, true)
             areas:save()

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -87,7 +87,7 @@ end
 ---@param ID number
 ---Returns the realm corresponding to the ID parameter.
 function Realm.GetRealm(ID)
-    return Realm.realmDict[ID]
+    return Realm.realmDict[tonumber(ID)]
 end
 
 -- Online bin packing... A pretty challenging problem to solve.

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -385,6 +385,17 @@ end
 function Realm:Delete()
     self:RunFunctionFromTable(self.RealmDeleteTable)
     self:CallOnDeleteCallbacks()
+
+    local spawn = mc_worldManager.GetSpawnRealm()
+    local players = self:GetPlayers()
+    if (players ~= nil) then
+        for k, v in pairs(players) do
+            if v == true then
+                spawn:TeleportPlayer(minetest.get_player_by_name(k))
+            end
+        end
+    end
+
     self:ClearNodes()
 
     if (areas) then

--- a/mods/mc_worldmanager/realm/realmAreasIntegration.lua
+++ b/mods/mc_worldmanager/realm/realmAreasIntegration.lua
@@ -6,7 +6,7 @@
 ---@param player table
 function Realm:AddPlayerArea(player)
     local playerName = player:get_player_name()
-    local realmArea = self:get_string("protectionID")
+    local realmArea = self:get_data("protectionID")
 
     if (self.MetaStorage.areas == nil) then
         self.MetaStorage.areas = {}

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -25,9 +25,9 @@ end
 ---@return table coordinates in worldspace
 function Realm.gridToWorldSpace(coords)
     local val = { x = 0, y = 0, z = 0 }
-    val.x = (coords.x * 80) - Realm.const.worldSize
-    val.y = (coords.y * 80) - Realm.const.worldSize
-    val.z = (coords.z * 80) - Realm.const.worldSize
+    val.x = (tonumber(coords.x) * 80) - Realm.const.worldSize
+    val.y = (tonumber(coords.y) * 80) - Realm.const.worldSize
+    val.z = (tonumber(coords.z) * 80) - Realm.const.worldSize
     return val
 end
 
@@ -35,9 +35,14 @@ end
 ---@param coords table coordinates in worldspace
 ---@return table coordinates in gridspace.
 function Realm.worldToGridSpace(coords)
+    Debug.logCoords(coords, "worldToGridSpaceStart")
+
     local val = { x = 0, y = 0, z = 0 }
-    val.x = math.ceil((coords.x + Realm.const.worldSize) / 80)
-    val.y = math.ceil((coords.y + Realm.const.worldSize) / 80)
-    val.z = math.ceil((coords.z + Realm.const.worldSize) / 80)
+    val.x = math.ceil((tonumber(coords.x) + Realm.const.worldSize) / 80)
+    val.y = math.ceil((tonumber(coords.y) + Realm.const.worldSize) / 80)
+    val.z = math.ceil((tonumber(coords.z) + Realm.const.worldSize) / 80)
+
+    Debug.logCoords(val, "worldToGridSpaceEnd")
+
     return val
 end

--- a/mods/mc_worldmanager/realm/realmDataManagement.lua
+++ b/mods/mc_worldmanager/realm/realmDataManagement.lua
@@ -74,6 +74,11 @@ function Realm:Restore(template)
     return this
 end
 
+---@public
+---set_data
+---Saves data into the realms metadata. This data will be serialized and saved with the realm.
+---@param key any
+---@param value any
 function Realm:set_data(key, value)
     if (self.MetaStorage == nil) then
         self.MetaStorage = {}
@@ -82,6 +87,11 @@ function Realm:set_data(key, value)
     self.MetaStorage[key] = value
 end
 
+---@public
+---get_data
+---Retrieves data from the realms metadata.
+---@param key any
+---@return any
 function Realm:get_data(key)
     if (self.MetaStorage == nil) then
         self.MetaStorage = {}
@@ -90,6 +100,11 @@ function Realm:get_data(key)
     return self.MetaStorage[key]
 end
 
+---@public
+---set_tmpData
+---Saves data into temporary realm metadata. This data is not saved with the realm.
+---@param key any
+---@param value any
 function Realm:set_tmpData(key, value)
     if (Realm.tempData[self] == nil) then
         Realm.tempData[self] = {}
@@ -98,6 +113,11 @@ function Realm:set_tmpData(key, value)
     Realm.tempData[self][key] = value
 end
 
+---@public
+---get_data
+---Retrieves data from the realms temporary metadata.
+---@param key any
+---@return any
 function Realm:get_tmpData(key)
     if (Realm.tempData[self] == nil) then
         Realm.tempData[self] = {}

--- a/mods/mc_worldmanager/realm/realmDataManagement.lua
+++ b/mods/mc_worldmanager/realm/realmDataManagement.lua
@@ -1,3 +1,6 @@
+Realm.tempData = {}
+
+
 ---@private
 ---Loads the persistant global data for the realm class
 ---@return void
@@ -35,7 +38,7 @@ end
 ---@private
 ---Saves the persistant global data for the realm class
 ---@return void
-function Realm.SaveDataToStorage ()
+function Realm.SaveDataToStorage()
     mc_worldManager.storage:set_string("realmDict", minetest.serialize(Realm.realmDict))
     mc_worldManager.storage:set_string("realmCount", tostring(Realm.realmCount))
 
@@ -71,18 +74,34 @@ function Realm:Restore(template)
     return this
 end
 
-function Realm:set_string(key, value)
+function Realm:set_data(key, value)
+    if (self.MetaStorage == nil) then
+        self.MetaStorage = {}
+    end
+
     self.MetaStorage[key] = value
 end
 
-function Realm:get_string(key)
+function Realm:get_data(key)
+    if (self.MetaStorage == nil) then
+        self.MetaStorage = {}
+    end
+
     return self.MetaStorage[key]
 end
 
-function Realm:set_int(key, value)
-    self.MetaStorage[key] = tostring(value)
+function Realm:set_tmpData(key, value)
+    if (Realm.tempData[self] == nil) then
+        Realm.tempData[self] = {}
+    end
+
+    Realm.tempData[self][key] = value
 end
 
-function Realm:get_int(key)
-    return tonumber(self.MetaStorage[key])
+function Realm:get_tmpData(key)
+    if (Realm.tempData[self] == nil) then
+        Realm.tempData[self] = {}
+    end
+
+    return Realm.tempData[self][key]
 end

--- a/mods/mc_worldmanager/realm/realmDataManagement.lua
+++ b/mods/mc_worldmanager/realm/realmDataManagement.lua
@@ -110,7 +110,7 @@ function Realm:set_tmpData(key, value)
         Realm.tempData[self] = {}
     end
 
-    Realm.tempData[self][key] = value
+    Realm.tempData[self][string.lower(key)] = value
 end
 
 ---@public
@@ -123,5 +123,5 @@ function Realm:get_tmpData(key)
         Realm.tempData[self] = {}
     end
 
-    return Realm.tempData[self][key]
+    return Realm.tempData[self][string.lower(key)]
 end

--- a/mods/mc_worldmanager/realm/realmIntegrationHelpers.lua
+++ b/mods/mc_worldmanager/realm/realmIntegrationHelpers.lua
@@ -1,0 +1,45 @@
+Realm.onCreateRealmCallbackTable = {}
+Realm.onDeleteRealmCallbackTable = {}
+Realm.onJoinRealmCallbackTable = {}
+Realm.onLeaveRealmCallbackTable = {}
+
+function Realm.RegisterOnCreateCallback(func)
+    table.insert(Realm.onCreateRealmCallbackTable, func)
+end
+
+function Realm.RegisterOnDeleteRealmCallback(func)
+    table.insert(Realm.onDeleteRealmCallbackTable, func)
+end
+
+function Realm.RegisterOnJoinCallback(func)
+    table.insert(Realm.onJoinRealmCallbackTable, func)
+end
+
+function Realm.RegisterOnLeaveCallback(func)
+    table.insert(Realm.onLeaveRealmCallbackTable, func)
+end
+
+function Realm:CallOnCreateCallbacks()
+    for _, func in ipairs(Realm.onCreateRealmCallbackTable) do
+        func(self)
+    end
+end
+
+function Realm:CallOnDeleteCallbacks()
+    for _, func in ipairs(Realm.onDeleteRealmCallbackTable) do
+        func(self)
+    end
+end
+
+function Realm:CallOnJoinCallbacks()
+    for _, func in ipairs(Realm.onJoinRealmCallbackTable) do
+        func(self, player)
+    end
+end
+
+function Realm:CallOnLeaveCallbacks()
+    for _, func in ipairs(Realm.onLeaveRealmCallbackTable) do
+        func(self, player)
+    end
+end
+

--- a/mods/mc_worldmanager/realm/realmIntegrationHelpers.lua
+++ b/mods/mc_worldmanager/realm/realmIntegrationHelpers.lua
@@ -31,13 +31,13 @@ function Realm:CallOnDeleteCallbacks()
     end
 end
 
-function Realm:CallOnJoinCallbacks()
+function Realm:CallOnJoinCallbacks(player)
     for _, func in ipairs(Realm.onJoinRealmCallbackTable) do
         func(self, player)
     end
 end
 
-function Realm:CallOnLeaveCallbacks()
+function Realm:CallOnLeaveCallbacks(player)
     for _, func in ipairs(Realm.onLeaveRealmCallbackTable) do
         func(self, player)
     end

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -98,3 +98,10 @@ end
 function Realm:GetPlayerNames()
     return self:get_tmpData("Inhabitants")
 end
+
+---@public
+---GetPlayerCount retrieves the number of players currently in this realm.
+---@return number of players currently in this realm.
+function Realm:GetPlayerCount()
+    return #self:get_tmpData("Inhabitants")
+end

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -5,6 +5,7 @@ function Realm:TeleportPlayer(player)
         local oldRealm = Realm.realmDict[OldRealmID]
         if (oldRealm ~= nil) then
             oldRealm:RunTeleportOutFunctions(player)
+            oldRealm:RemovePlayer(player)
         end
     end
 
@@ -12,6 +13,7 @@ function Realm:TeleportPlayer(player)
     local spawn = self.SpawnPoint
     player:set_pos(spawn)
 
+    self:AddPlayer(player)
     mc_worldManager.updateHud(player)
 end
 
@@ -34,4 +36,35 @@ end
 
 function Realm:RunTeleportOutFunctions(player)
     self:RunFunctionFromTable(self.PlayerLeaveTable, player)
+end
+
+function Realm:AddPlayer(player)
+    local table = self:get_tmpData("Inhabitants")
+    if (table == nil) then
+        table = {}
+    end
+    table[player:get_player_name()] = true
+    self:set_tmpData("Inhabitants", table)
+end
+
+function Realm:RemovePlayer(player)
+    local table = self:get_tmpData("Inhabitants")
+    if (table == nil) then
+        table = {}
+    end
+    table[player:get_player_name()] = nil
+    self:set_tmpData("Inhabitants", table)
+end
+
+function Realm.ScanForPlayers()
+
+end
+
+
+function Realm.GetRealmFromPlayer(player)
+    local pmeta = player:get_meta()
+    local playerRealmID = pmeta:get_int("realm")
+
+    local realm = Realm.realmDict[playerRealmID]
+    return realm
 end

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -38,14 +38,17 @@ end
 ---@private
 function Realm:RunTeleportInFunctions(player)
     self:RunFunctionFromTable(self.PlayerJoinTable, player)
+    self:CallOnJoinCallbacks(player)
 end
 
 ---@private
 function Realm:RunTeleportOutFunctions(player)
     self:RunFunctionFromTable(self.PlayerLeaveTable, player)
+    self:CallOnLeaveCallbacks(player)
 end
 
 ---@private
+---@param table table
 function Realm:RegisterPlayer(player)
     local table = self:get_tmpData("Inhabitants")
     if (table == nil) then
@@ -56,6 +59,7 @@ function Realm:RegisterPlayer(player)
 end
 
 ---@private
+---@param player objectRef
 function Realm:DeregisterPlayer(player)
     local table = self:get_tmpData("Inhabitants")
     if (table == nil) then

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -91,3 +91,10 @@ function Realm.GetRealmFromPlayer(player)
     local realm = Realm.realmDict[playerRealmID]
     return realm
 end
+
+---@public
+---GetPlayerNames retrieves a table of the current inhabitants of this realm.
+---@return table containing the names of players currently in this realm.
+function Realm:GetPlayerNames()
+    return self:get_tmpData("Inhabitants")
+end

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -97,10 +97,21 @@ function Realm.GetRealmFromPlayer(player)
 end
 
 ---@public
----GetPlayerNames retrieves a table of the current inhabitants of this realm.
+---GetPlayers retrieves a table containing the current inhabitants of this realm.
 ---@return table containing the names of players currently in this realm.
-function Realm:GetPlayerNames()
+function Realm:GetPlayers()
     return self:get_tmpData("Inhabitants")
+end
+
+function Realm:GetPlayersAsArray()
+    local players = self:GetPlayers()
+    local retval = {}
+    for k, v in pairs(players) do
+        if (v == true) then
+            table.insert(retval, k)
+        end
+    end
+    return retval
 end
 
 ---@public

--- a/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
+++ b/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
@@ -87,7 +87,29 @@ function Realm:Load_Schematic(schematic, config)
 
     --TODO: Add code to check if the realm is large enough to support the schematic; If not, create a new realm that can;
     local schematicEndPos = self:LocalToWorldPosition(config.schematicSize)
-    self.EndPos = schematicEndPos
+
+    if (schematicEndPos.x > self.EndPos.x or schematicEndPos.y > self.EndPos.y or schematicEndPos.z > self.EndPos.z) then
+        Debug.log("Schematic is too large for realm")
+    else
+        if (schematicEndPos.x == nil or schematicEndPos == 0) then
+            schematicEndPos.x = 80
+            Debug.log("Schematic size x is 0, setting to 80")
+        end
+
+        if (schematicEndPos.y == nil or schematicEndPos == 0) then
+            schematicEndPos.y = 80
+            Debug.log("Schematic size y is 0, setting to 80")
+        end
+
+        if (schematicEndPos.z == nil or schematicEndPos == 0) then
+            schematicEndPos.z = 80
+            Debug.log("Schematic size z is 0, setting to 80")
+        end
+
+        self.EndPos = schematicEndPos
+    end
+
+
 
 
     --exschem is having issues loading random chunks, need to debug


### PR DESCRIPTION
This PR adds the following features:
- Added player tracking to the realms system to allow realms integrations to know which players are located within the realm 
- Added callbacks for essential parts of the realms (onRealmCreate, onRealmDestroy, onPlayerJoin, onPlayerLeave). This allows mods to be integrated with the realms system without creating cyclical dependencies
- Simplified the realms API for common tasks (such as getting the realm a player is located, getting a realm from a realm ID)

To solve point 3 from #36: 
- Added realm selection target to the `mc_teacher` mod. This selection target is used by default to help prevent teachers from accidentally targeting all players. 
- Added a "realm" tab to the mc_teacher players menu which displays all players in the current realm
- Fixed the classrooms system to properly work with the realms system again (it had broke in an unknown merge).  