### PR TITLE
Added a check to avoid setting players health to a negative number

### DIFF
--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -121,6 +121,10 @@ minetest.register_globalstep(function(deltaTime)
             end
 
             player:set_hp(hp, "void")
+
+            if (player:get_hp() < 0) then
+                player:set_hp(0, "void")
+            end
         end
 
 


### PR DESCRIPTION
This PR adds a check to prevent setting player health to a negative value -- causing weird things like player invincibility.