### PR TITLE
Refactor forestry tools to use `mc_toolhandler` give/take framework

### DIFF
--- a/mods/forestry-tools/clinometer.lua
+++ b/mods/forestry-tools/clinometer.lua
@@ -2,7 +2,7 @@
 -- IN-PROGRESS: show yaw (horizontal angle) and pitch (vertical viewing angle) in degrees.
 
 -- <!> This is important, since calls to S() are made in this file - without this, the game will crash
-local S = minetest.get_translator("forestry_tools")
+local S = forestry_tools.S
 local HUD_showing = false; 
 
 
@@ -15,7 +15,7 @@ minetest.register_tool("forestry_tools:clinometer", {
 	wield_image = "clinometer.png",
 	inventory_image = "clinometer.png",
 	groups = { disable_repair = 1 },
-
+	_mc_tool_privs = forestry_tools.priv_table,
 
 			
 		-- On left-click
@@ -30,7 +30,6 @@ minetest.register_tool("forestry_tools:clinometer", {
 		
     	-- Destroy the item on_drop to keep things tidy
 	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
 	end
 })
 
@@ -40,29 +39,7 @@ minetest.register_alias("clinometer", "forestry_tools:clinometer")
 clinometer = minetest.registered_aliases[clinometer] or clinometer
 
 
--- Give the clinometer to any player who joins with adequate privileges or take it away if they do not have them
-minetest.register_on_joinplayer(function(player)
-    local inv = player:get_inventory()
-    if inv:contains_item("main", ItemStack("forestry_tools:clinometer")) then
-        -- Player has the clinometer
-        if check_perm(player) then
-            -- The player should have the clinometer
-            return
-        else   
-            -- The player should not have the clinometer
-            player:get_inventory():remove_item('main', "forestry_tools:compass")
-        end
-    else
-        -- Player does not have the clinometer
-        if check_perm(player) then
-            -- The player should have the clinometer
-            player:get_inventory():add_item('main', "forestry_tools:clinometer")
-        else
-            -- The player should not have the clinometer
-            return
-        end     
-    end
-end)
+
 
 
 

--- a/mods/forestry-tools/compass.lua
+++ b/mods/forestry-tools/compass.lua
@@ -182,6 +182,7 @@ minetest.register_tool("forestry_tools:compass" , {
 	inventory_image = "needle_0.png",
     stack_max = 1,
 	liquids_pointable = true,
+	_mc_tool_privs = forestry_tools.priv_table,
 
 	-- On left-click
     on_use = function(itemstack, player, pointed_thing)
@@ -225,7 +226,6 @@ minetest.register_tool("forestry_tools:compass" , {
 
 	-- Destroy the item on_drop 
 	on_drop = function (itemstack, dropper, pos)
-		minetest.set_node(pos, {name="air"})
 	end,
 })
 

--- a/mods/forestry-tools/init.lua
+++ b/mods/forestry-tools/init.lua
@@ -1,7 +1,11 @@
-forestry_tools = { path = minetest.get_modpath("forestry_tools") }
+forestry_tools = {
+	path = minetest.get_modpath("forestry_tools"),
+	S = minetest.get_translator("forestry_tools"),
+	priv_table = { interact = true }
+}
 
-function check_perm(player)
-	return minetest.check_player_privs(player:get_player_name(), { shout = true })
+function forestry_tools.check_perm(player)
+	return minetest.check_player_privs(player:get_player_name(), forestry_tools.priv_table)
 end
 
 dofile(forestry_tools.path .. "/measuring_tape.lua")

--- a/mods/forestry-tools/measuring_tape.lua
+++ b/mods/forestry-tools/measuring_tape.lua
@@ -19,27 +19,6 @@ minetest.register_on_joinplayer(function(player)
 		orig_nodes = {},
 		mark_status = none_set
 	}
-
-    local inv = player:get_inventory()
-    if inv:contains_item("main", ItemStack("forestry_tools:measuringTape")) then
-        -- Player has the measuring tape
-        if check_perm(player) then
-            -- The player should have the measuring tape
-            return
-        else   
-            -- The player should not have the measuring tape
-            player:get_inventory():remove_item('main', "forestry_tools:measuringTape")
-        end
-    else
-        -- Player does not have the measuring tape
-        if check_perm(player) then
-            -- The player should have the measuring tape
-            player:get_inventory():add_item('main', "forestry_tools:measuringTape")
-        else
-            -- The player should not have the measuring tape
-            return
-        end     
-    end
 end)
 
 
@@ -197,6 +176,7 @@ minetest.register_tool("forestry_tools:measuringTape" , {
 	inventory_image = "measuring_tape.png",
     stack_max = 1,
 	liquids_pointable = true,
+	_mc_tool_privs = forestry_tools.priv_table,
 
 	-- On left-click
     on_use = function(itemstack, placer, pointed_thing)

--- a/mods/forestry-tools/rangefinder.lua
+++ b/mods/forestry-tools/rangefinder.lua
@@ -317,7 +317,7 @@ minetest.register_tool(tool_name , {
  	on_use = function(itemstack, player, pointed_thing)
         local pname = player:get_player_name()
  		-- Check for shout privileges
- 		if check_perm(player) then
+ 		if forestry_tools.check_perm(player) then
             local new_stack, cast_num, cast_complete = track_raycast_hit(player, itemstack)
             if new_stack then
                 local meta = new_stack:get_meta()
@@ -447,26 +447,3 @@ minetest.register_on_joinplayer(function(player)
         end
     end
 end)
-
--- minetest.register_on_joinplayer(function(player)
---     local inv = player:get_inventory()
---     if inv:contains_item("main", ItemStack("forestry_tools:rangefinder")) then
---         -- Player has the rangefinder
---         if check_perm(player) then
---             -- The player should have the rangefinder
---             return
---         else   
---             -- The player should not have the rangefinder
---             player:get_inventory():remove_item('main', "forestry_tools:rangefinder")
---         end
---     else
---         -- Player does not have the rangefinder
---         if check_perm(player) then
---             -- The player should have the rangefinder
---             player:get_inventory():add_item('main', "forestry_tools:rangefinder")
---         else
---             -- The player should not have the rangefinder
---             return
---         end     
---     end
--- end)

--- a/mods/forestry-tools/wedgeprism.lua
+++ b/mods/forestry-tools/wedgeprism.lua
@@ -1,11 +1,14 @@
-local S = minetest.get_translator("forestry_tools")
+local S = forestry_tools.S
 
 -- Allows zooming
  minetest.register_tool("forestry_tools:wedgeprism", {
-             description = S("Wedge Prism"),
-            wield_image = "wedgeprism.jpg",
-            inventory_image = "wedgeprism.jpg",
-     })
+    description = S("Wedge Prism"),
+    wield_image = "wedgeprism.jpg",
+    inventory_image = "wedgeprism.jpg",
+	_mc_tool_privs = forestry_tools.priv_table,
+	on_drop = function(itemstack, dropper, pos)
+	end,
+})
 
 
 minetest.register_privilege("alwayszoom", {})


### PR DESCRIPTION
Properly merges refactor from #101
* Add `S` and `check_perm` to global `forestry_tools` table
* Remove legacy tool give/take code and replace with `mc_toolhandler` config code
* Patch instances of `on_drop` bug in `forestry_tools` (#71)