### PR TITLE
Feature/utm coordinates

### DIFF
--- a/mods/mc_helpers/init.lua
+++ b/mods/mc_helpers/init.lua
@@ -159,3 +159,7 @@ function mc_helpers.deepCopy(table)
     end
     return copy
 end
+
+function mc_helpers.round(x, n)
+    return tonumber(string.format("%." .. n .. "f", x))
+end

--- a/mods/mc_teacher/maps/MKRF512_all.conf
+++ b/mods/mc_teacher/maps/MKRF512_all.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/MKRF512_aspect.conf
+++ b/mods/mc_teacher/maps/MKRF512_aspect.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/MKRF512_dtm.conf
+++ b/mods/mc_teacher/maps/MKRF512_dtm.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/MKRF512_hillshade.conf
+++ b/mods/mc_teacher/maps/MKRF512_hillshade.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/MKRF512_slope.conf
+++ b/mods/mc_teacher/maps/MKRF512_slope.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/MKRF512_tpi.conf
+++ b/mods/mc_teacher/maps/MKRF512_tpi.conf
@@ -7,3 +7,7 @@ schematic_size_x = 513
 schematic_size_y = 175
 schematic_size_z = 513
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_teacher/maps/vancouver_osm.conf
+++ b/mods/mc_teacher/maps/vancouver_osm.conf
@@ -8,3 +8,7 @@ schematic_size_x = 201
 schematic_size_y = 160
 schematic_size_z = 201
 license = CC BY-SA 4.0
+utm_zone = 10
+utm_north = true
+utm_origin_easting = 533244
+utm_origin_northing = 5464244

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -601,6 +601,12 @@ commands["coordinates"] = {
         local playerRealm = Realm.GetRealmFromPlayer(minetest.get_player_by_name(name))
 
         if (operation == "set") then
+            if (format == "UTM") then
+                if (utmInfo == nil) then
+                    utmInfo = { easting = tonumber(params[3]), northing = tonumber(params[4]), zone = tonumber(params[5]), utm_is_north = tostring(params[6]) }
+                end
+                playerRealm:set_data("UTMInfo", utmInfo)
+            end
 
         elseif (operation == "get") then
             local rawPos = minetest.get_player_by_name(name):getpos()
@@ -614,7 +620,7 @@ commands["coordinates"] = {
                 pos = Realm.worldToGridSpace(rawPos)
             elseif (format == "utm") then
                 pos = playerRealm:WorldToUTM(rawPos)
-                elseif (format == "latlong") then
+            elseif (format == "latlong") then
                 pos = playerRealm:WorldToLatLong(rawPos)
             else
                 return false, "unknown format: " .. tostring(format)

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -606,7 +606,9 @@ commands["coordinates"] = {
                     utmInfo = { easting = tonumber(params[3]), northing = tonumber(params[4]), zone = tonumber(params[5]), utm_is_north = tostring(params[6]) }
                 end
                 playerRealm:set_data("UTMInfo", utmInfo)
+                return true
             end
+            return false, "invalid format."
 
         elseif (operation == "get") then
             local rawPos = minetest.get_player_by_name(name):getpos()
@@ -628,11 +630,22 @@ commands["coordinates"] = {
 
             minetest.chat_send_player(name, "Format: X: " .. tostring(pos.x) .. " Y: " .. tostring(pos.y) .. " Z: " .. tostring(pos.z))
             return true, "command executed succesfully"
+
+        elseif (operation == "hud") then
+            if (mc_worldManager.positionTextFunctions[format] ~= nil) then
+                pmeta:set_string("positionHudMode", format)
+                return true, "enabled position hud element for format " .. format .. "."
+            elseif (format == "nil" or format == "none") then
+                pmeta:set_string("positionHudMode", "")
+                mc_worldManager.RemovePositionHud(minetest.get_player_by_name(name))
+                return true, "disabled position hud element."
+            end
+            return false, "invalid format."
         end
 
-        return false, "unknown sub-command."
+        return false, "unknown command parameters."
     end,
-    help = "realm coordinates <set | get> <format>"
+    help = "realm coordinates <set | get | hud> <format (world, grid, local, utm, latlong)>"
 }
 
 commands["data"] = {

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -614,13 +614,47 @@ commands["coordinates"] = {
                 pos = Realm.worldToGridSpace(rawPos)
             elseif (format == "utm") then
                 pos = playerRealm:WorldToUTM(rawPos)
+                elseif (format == "latlong") then
+                pos = playerRealm:WorldToLatLong(rawPos)
+            else
+                return false, "unknown format: " .. tostring(format)
             end
 
             minetest.chat_send_player(name, "Format: X: " .. tostring(pos.x) .. " Y: " .. tostring(pos.y) .. " Z: " .. tostring(pos.z))
             return true, "command executed succesfully"
         end
+
+        return false, "unknown sub-command."
     end,
     help = "realm coordinates <set | get> <format>"
+}
+
+commands["data"] = {
+    func = function(name, params)
+        local operation = tostring(params[2])
+        local realmID = tonumber(params[1])
+        local realm = Realm.GetRealm(realmID)
+        if (realm == nil) then
+            return false, "realm " .. tostring(realmID) .. " does not exist."
+        end
+        if (operation == "get") then
+            local data = realm:get_data(tostring(params[3]))
+            if (data == nil) then
+                return false, "data " .. tostring(params[3]) .. " does not exist."
+            end
+            minetest.chat_send_player(name, "Data: " .. tostring(data))
+            return true, "command executed succesfully"
+        elseif (operation == "set") then
+            realm:set_data(tostring(params[3]), tostring(params[4]))
+            return true, "command executed succesfully"
+        elseif (operation == "dump") then
+            local data = realm.MetaStorage
+            minetest.chat_send_player(name, "Data: " .. tostring(minetest.serialize(data)))
+            return true, "command executed succesfully"
+        end
+        return false, "unknown sub-command."
+    end,
+    help = "realm data <get | set> <realmID> <dataName> <dataValue>"
 }
 
 minetest.register_chatcommand("realm", {

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -277,14 +277,11 @@ commands["schematic"] = {
             local schemName = tostring(params[2])
             Debug.log(schemName)
 
-
             local subparam = tostring(params[3])
 
             if (subparam == "" or subparam == "nil") then
                 subparam = "old"
             end
-
-
 
             local path = requestedRealm:Save_Schematic(schemName, name, subparam)
             return true, "Saved realm with ID " .. realmID .. " at path: " .. path
@@ -594,6 +591,36 @@ commands["blocks"] = {
     end,
     help = "realm blocks <block> <count> (<instanced: true | false> | <realmID>) <temporary: true | false> <realmName> <schematic>"
 
+}
+
+commands["coordinates"] = {
+    func = function(name, params)
+        local operation = tostring(params[1])
+        local format = tostring(params[2])
+
+        local playerRealm = Realm.GetRealmFromPlayer(minetest.get_player_by_name(name))
+
+        if (operation == "set") then
+
+        elseif (operation == "get") then
+            local rawPos = minetest.get_player_by_name(name):getpos()
+            local pos
+
+            if (format == "world") then
+                pos = rawPos
+            elseif (format == "local" or format == "nil") then
+                pos = playerRealm.WorldToLocalPosition(rawPos)
+            elseif (format == "grid") then
+                pos = Realm.worldToGridSpace(rawPos)
+            elseif (format == "utm") then
+                pos = playerRealm:WorldToUTM(rawPos)
+            end
+
+            minetest.chat_send_player(name, "Format: X: " .. tostring(pos.x) .. " Y: " .. tostring(pos.y) .. " Z: " .. tostring(pos.z))
+            return true, "command executed succesfully"
+        end
+    end,
+    help = "realm coordinates <set | get> <format>"
 }
 
 minetest.register_chatcommand("realm", {

--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -32,7 +32,7 @@ minetest.register_on_joinplayer(function(player, last_login)
         pmeta:set_string("universalPrivs", minetest.serialize(minetest.get_player_privs(player:get_player_name())))
     end
 
-    mc_worldManager.CreateHud(player)
+    mc_worldManager.CreateRealmHud(player)
 
     local realm = Realm.GetRealmFromPlayer(player)
     if (realm ~= nil) then
@@ -43,7 +43,8 @@ end)
 
 -- When player leave the game, we delete their hud
 minetest.register_on_leaveplayer(function(player, timed_out)
-    mc_worldManager.RemoveHud(player)
+    mc_worldManager.RemoveRealmHud(player)
+    mc_worldManager.RemovePositionHud(player)
 
     local realm = Realm.GetRealmFromPlayer(player)
     if (realm:getCategory() == "instanced") then
@@ -54,7 +55,6 @@ minetest.register_on_leaveplayer(function(player, timed_out)
     if (realm ~= nil) then
         realm:DeregisterPlayer(player)
     end
-
 end)
 
 mc_worldManager.tick = 0
@@ -132,7 +132,23 @@ minetest.register_globalstep(function(deltaTime)
             end
         end
     end
+end)
 
+mc_worldManager.hudTick = 0
+minetest.register_globalstep(function(deltaTime)
+    mc_worldManager.hudTick = mc_worldManager.hudTick + deltaTime
+
+    if (mc_worldManager.hudTick > 0.5) then
+        mc_worldManager.hudTick = 0
+
+        for id, player in ipairs(minetest.get_connected_players()) do
+            local pmeta = player:get_meta()
+            local positionHudMode = pmeta:get_string("positionHudMode")
+            if (positionHudMode ~= "") then
+                mc_worldManager.UpdatePositionHud(player, positionHudMode)
+            end
+        end
+    end
 
 end)
 

--- a/mods/mc_worldmanager/hud.lua
+++ b/mods/mc_worldmanager/hud.lua
@@ -42,19 +42,19 @@ end
 local positionText = {}
 
 positionText["latlong"] = function(player, realm)
-    local pos = realm:WorldToLatLong(player:get_pos())
+    local pos = realm:WorldToLatLongSpace(player:get_pos())
     local text = "Lat: " .. pos.x .. " Long: " .. pos.z
     return text
 end
 
 positionText["UTM"] = function(player, realm)
-    local pos = realm:WorldToUTM(player:get_pos())
+    local pos = realm:WorldToUTMSpace(player:get_pos())
     local text = "E: " .. math.ceil(pos.x) .. " N: " .. math.ceil(pos.z)
     return text
 end
 
 positionText["local"] = function(player, realm)
-    local pos = realm:WorldToLocal(player:get_pos())
+    local pos = realm:WorldToLocalSpace(player:get_pos())
     local text = "X: " .. math.ceil(pos.x) .. " Y: " .. math.ceil(pos.y) .. " Z: " .. math.ceil(pos.z)
     return text
 end
@@ -66,7 +66,7 @@ positionText["world"] = function(player, realm)
 end
 
 positionText["grid"] = function(player, realm)
-    local pos = realm:worldToGridSpace(player:get_pos())
+    local pos = realm.worldToGridSpace(player:get_pos())
     local text = "X: " .. pos.x .. " Y: " .. pos.y .. " Z: " .. pos.z
     return text
 end

--- a/mods/mc_worldmanager/hud.lua
+++ b/mods/mc_worldmanager/hud.lua
@@ -1,4 +1,4 @@
-local function createHudString(player)
+local function createRealmInfoHudString(player)
     local realm = Realm.GetRealmFromPlayer(player)
     local string = "Realm "
     if (realm ~= nil) then
@@ -8,18 +8,18 @@ local function createHudString(player)
     return string
 end
 
-function mc_worldManager.CreateHud(player)
+function mc_worldManager.CreateRealmHud(player)
     mc_worldManager.hud:add(player, "worldManager:currentRealm", {
         hud_elem_type = "text",
         position = { x = 1, y = 0 },
         offset = { x = -16, y = 5 },
         alignment = { x = "left", y = "down" },
-        text = createHudString(player),
+        text = createRealmInfoHudString(player),
         color = 0xFFFFFF,
     })
 end
 
-function mc_worldManager.updateHud(player)
+function mc_worldManager.UpdateRealmHud(player)
     if (not mc_worldManager.hud:exists(player, "worldManager:currentRealm")) then
         return false
     end
@@ -28,13 +28,81 @@ function mc_worldManager.updateHud(player)
         position = { x = 1, y = 0 },
         offset = { x = -16, y = 5 },
         alignment = { x = "left", y = "down" },
-        text = createHudString(player),
+        text = createRealmInfoHudString(player),
         color = 0xFFFFFF,
     })
 
     return true
 end
 
-function mc_worldManager.RemoveHud(player)
+function mc_worldManager.RemoveRealmHud(player)
     mc_worldManager.hud:remove(player)
+end
+
+local positionText = {}
+
+positionText["latlong"] = function(player, realm)
+    local pos = realm:WorldToLatLong(player:get_pos())
+    local text = "Lat: " .. pos.x .. " Long: " .. pos.z
+    return text
+end
+
+positionText["UTM"] = function(player, realm)
+    local pos = realm:WorldToUTM(player:get_pos())
+    local text = "E: " .. math.ceil(pos.x) .. " N: " .. math.ceil(pos.z)
+    return text
+end
+
+positionText["local"] = function(player, realm)
+    local pos = realm:WorldToLocal(player:get_pos())
+    local text = "X: " .. math.ceil(pos.x) .. " Y: " .. math.ceil(pos.y) .. " Z: " .. math.ceil(pos.z)
+    return text
+end
+
+positionText["world"] = function(player, realm)
+    local pos = player:get_pos()
+    local text = "X: " .. math.ceil(pos.x) .. " Y: " .. math.ceil(pos.y) .. " Z: " .. math.ceil(pos.z)
+    return text
+end
+
+positionText["grid"] = function(player, realm)
+    local pos = realm:worldToGridSpace(player:get_pos())
+    local text = "X: " .. pos.x .. " Y: " .. pos.y .. " Z: " .. pos.z
+    return text
+end
+
+mc_worldManager.positionTextFunctions = positionText
+
+-- Creating strings so often is very problematic and will create lots of garbage.
+-- There is no way (to my limited knowledge) around this under current requirements.
+-- I will try to fix this in the future.
+-- See http://lua-users.org/wiki/OptimisingGarbageCollection for more info on string garbage.
+function mc_worldManager.UpdatePositionHud(player, positionMode)
+    if (not mc_worldManager.hud:exists(player, "worldManager:position")) then
+        mc_worldManager.hud:add(player, "worldManager:position", {
+            hud_elem_type = "text",
+            position = { x = 1, y = 0 },
+            offset = { x = -16, y = 25 },
+            alignment = { x = "left", y = "down" },
+            text = "",
+            color = 0xFFFFFF,
+        })
+    end
+
+    local realm = Realm.GetRealmFromPlayer(player)
+
+    mc_worldManager.hud:change(player, "worldManager:position", {
+        hud_elem_type = "text",
+        position = { x = 1, y = 0 },
+        offset = { x = -16, y = 25 },
+        alignment = { x = "left", y = "down" },
+        text = positionText[positionMode](player, realm),
+        color = 0xFFFFFF,
+    })
+
+    return true
+end
+
+function mc_worldManager.RemovePositionHud(player)
+    mc_worldManager.hud:remove(player, "worldManager:position")
 end

--- a/mods/mc_worldmanager/realm/realm.lua
+++ b/mods/mc_worldmanager/realm/realm.lua
@@ -482,7 +482,7 @@ end
 ---@param spawnPos table SpawnPoint in localSpace.
 ---@return boolean Whether the operation succeeded.
 function Realm:UpdateSpawn(spawnPos)
-    local pos = self:LocalToWorldPosition(spawnPos)
+    local pos = self:LocalToWorldSpace(spawnPos)
     self.SpawnPoint = { x = pos.x, y = pos.y, z = pos.z }
     Realm.SaveDataToStorage()
     return true

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -24,9 +24,7 @@ function Realm:LocalToUTM(position)
     local utmInfo = self:get_data("UTMInfo")
 
     if (utmInfo == nil) then
-        utmInfo = {}
-        utmInfo.easting = 0
-        utmInfo.northing = 0
+        utmInfo = { zone = 0, utm_is_north = true, easting = 0, northing = 0 }
     end
 
     local x = position.x + utmInfo.easting

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -1,7 +1,7 @@
----LocalToWorldPosition
+---LocalToWorldSpace
 ---@param position table coordinates
 ---@return table localspace coordinates.
-function Realm:LocalToWorldPosition(position)
+function Realm:LocalToWorldSpace(position)
     local pos = position
     pos.x = pos.x + self.StartPos.x
     pos.y = pos.y + self.StartPos.y
@@ -9,10 +9,10 @@ function Realm:LocalToWorldPosition(position)
     return pos
 end
 
----WorldToLocalPosition
+---WorldToLocalSpace
 ---@param position table coordinates in worldspace
 ---@return table worldspace coordinates
-function Realm:WorldToLocalPosition(position)
+function Realm:WorldToLocalSpace(position)
     local pos = position
     pos.x = pos.x - self.StartPos.x
     pos.y = pos.y - self.StartPos.y
@@ -20,7 +20,7 @@ function Realm:WorldToLocalPosition(position)
     return pos
 end
 
-function Realm:LocalToUTM(position)
+function Realm:LocalToUTMSpace(position)
     local utmInfo = self:get_data("UTMInfo")
 
     if (utmInfo == nil) then
@@ -31,17 +31,17 @@ function Realm:LocalToUTM(position)
     local z = position.z + utmInfo.northing
 
     return {
-        x = math.floor(x),
-        y = math.floor(position.y),
-        z = math.floor(z)
+        x = x,
+        y = position.y,
+        z = z
     }
 end
 
-function Realm:WorldToUTM(position)
-    return self:LocalToUTM(self:WorldToLocalPosition(position))
+function Realm:WorldToUTMSpace(position)
+    return self:LocalToUTMSpace(self:WorldToLocalSpace(position))
 end
 
-function Realm:UTMToLocal(position)
+function Realm:UTMToLocalSpace(position)
     local utmInfo = self:get_data("utmInfo")
 
     if (utmInfo == nil) then
@@ -84,13 +84,13 @@ function Realm.worldToGridSpace(coords)
     return val
 end
 
-function Realm:WorldToLatLong(position)
+function Realm:WorldToLatLongSpace(position)
     local utmInfo = self:get_data("UTMInfo")
     if (utmInfo == nil) then
         utmInfo = { zone = 0, utm_is_north = true, easting = 0, northing = 0 }
     end
 
-    local position = self:WorldToUTM(position)
+    local position = self:WorldToUTMSpace(position)
 
     local latlongPosition = Realm.UTMToLatLong(position.x, position.z, utmInfo.zone, utmInfo.utm_is_north)
 

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -162,8 +162,8 @@ end
 ]]--
 
 function Realm.UTMToLatLong(Easting, Northing, Zone, Hemisphere)
-    local DtoR = Math.PI / 180
-    local RtoD = 180 / Math.PI;
+    local DtoR = math.pi / 180
+    local RtoD = 180 / math.pi;
 
     local a = 6378137
     local f = 0.00335281066474748071984552861852
@@ -171,43 +171,54 @@ function Realm.UTMToLatLong(Easting, Northing, Zone, Hemisphere)
     local southernN0 = 10000000
     local E0 = 500000
 
+    -- Caching our Math variables for better performance
+    local Math = { }
+    Math.Pow = math.pow
+    Math.Sin = math.sin
+    Math.Cos = math.cos
+    Math.Asin = math.asin
+    Math.Atan = math.atan
+    Math.Cosh = math.cosh
+    Math.Sinh = math.sinh
 
-    n = f / (2 - f)
-    k0 = 0.9996
-    A = a * (1 + (1 / 4) * Math.Pow(n, 2) + (1 / 64) * Math.Pow(n, 4) + (1 / 256) * Math.Pow(n, 6) + (25 / 16384) * Math.Pow(n, 8) + (49 / 65536) * Math.Pow(n, 10)) / (1 + n)
+    local n = f / (2 - f)
+    local k0 = 0.9996
+    local A = a * (1 + (1 / 4) * Math.Pow(n, 2) + (1 / 64) * Math.Pow(n, 4) + (1 / 256) * Math.Pow(n, 6) + (25 / 16384) * Math.Pow(n, 8) + (49 / 65536) * Math.Pow(n, 10)) / (1 + n)
 
-    beta1 = n / 2 - (2 / 3) * Math.Pow(n, 2) + (37 / 96) * Math.Pow(n, 3) - (1 / 360) * Math.Pow(n, 4) - (81 / 512) * Math.Pow(n, 5) + (96199 / 604800) * Math.Pow(n, 6) - (5406467 / 38707200) * Math.Pow(n, 7) + (7944359 / 67737600) * Math.Pow(n, 8) - (7378753979 / 97542144000) * Math.Pow(n, 9) + (25123531261 / 804722688000) * Math.Pow(n, 10)
-    beta2 = (1 / 48) * Math.Pow(n, 2) + (1 / 15) * Math.Pow(n, 3) - (437 / 1440) * Math.Pow(n, 4) + (46 / 105) * Math.Pow(n, 5) - (1118711 / 3870720) * Math.Pow(n, 6) + (51841 / 1209600) * Math.Pow(n, 7) + (24749483 / 348364800) * Math.Pow(n, 8) - (115295683 / 1397088000) * Math.Pow(n, 9) + (5487737251099 / 51502252032000) * Math.Pow(n, 10)
-    beta3 = (17 / 480) * Math.Pow(n, 3) - (37 / 840) * Math.Pow(n, 4) - (209 / 4480) * Math.Pow(n, 5) + (5569 / 90720) * Math.Pow(n, 6) + (9261899 / 58060800) * Math.Pow(n, 7) - (6457463 / 17740800) * Math.Pow(n, 8) + (2473691167 / 9289728000) * Math.Pow(n, 9) - (852549456029 / 20922789888000) * Math.Pow(n, 10)
-    beta4 = (4397 / 161280) * Math.Pow(n, 4) - (11 / 504) * Math.Pow(n, 5) - (830251 / 7257600) * Math.Pow(n, 6) + (466511 / 2494800) * Math.Pow(n, 7) + (324154477 / 7664025600) * Math.Pow(n, 8) - (937932223 / 3891888000) * Math.Pow(n, 9) - (89112264211 / 5230697472000) * Math.Pow(n, 10)
-    beta5 = (4583 / 161280) * Math.Pow(n, 5) - (108847 / 3991680) * Math.Pow(n, 6) - (8005831 / 63866880) * Math.Pow(n, 7) + (22894433 / 124540416) * Math.Pow(n, 8) + (112731569449 / 557941063680) * Math.Pow(n, 9) - (5391039814733 / 10461394944000) * Math.Pow(n, 10)
-    beta6 = (20648693 / 638668800) * Math.Pow(n, 6) - (16363163 / 518918400) * Math.Pow(n, 7) - (2204645983 / 12915302400) * Math.Pow(n, 8) + (4543317553 / 18162144000) * Math.Pow(n, 9) + (54894890298749 / 167382319104000) * Math.Pow(n, 10)
-    beta7 = (219941297 / 5535129600) * Math.Pow(n, 7) - (497323811 / 12454041600) * Math.Pow(n, 8) - (79431132943 / 332107776000) * Math.Pow(n, 9) + (4346429528407 / 12703122432000) * Math.Pow(n, 10)
-    beta8 = (191773887257 / 3719607091200) * Math.Pow(n, 8) - (17822319343 / 336825216000) * Math.Pow(n, 9) - (497155444501631 / 1422749712384000) * Math.Pow(n, 10)
-    beta9 = (11025641854267 / 158083301376000) * Math.Pow(n, 9) - (492293158444691 / 6758061133824000) * Math.Pow(n, 10)
-    beta10 = (7028504530429621 / 72085985427456000) * Math.Pow(n, 10)
+    local beta1 = n / 2 - (2 / 3) * Math.Pow(n, 2) + (37 / 96) * Math.Pow(n, 3) - (1 / 360) * Math.Pow(n, 4) - (81 / 512) * Math.Pow(n, 5) + (96199 / 604800) * Math.Pow(n, 6) - (5406467 / 38707200) * Math.Pow(n, 7) + (7944359 / 67737600) * Math.Pow(n, 8) - (7378753979 / 97542144000) * Math.Pow(n, 9) + (25123531261 / 804722688000) * Math.Pow(n, 10)
+    local beta2 = (1 / 48) * Math.Pow(n, 2) + (1 / 15) * Math.Pow(n, 3) - (437 / 1440) * Math.Pow(n, 4) + (46 / 105) * Math.Pow(n, 5) - (1118711 / 3870720) * Math.Pow(n, 6) + (51841 / 1209600) * Math.Pow(n, 7) + (24749483 / 348364800) * Math.Pow(n, 8) - (115295683 / 1397088000) * Math.Pow(n, 9) + (5487737251099 / 51502252032000) * Math.Pow(n, 10)
+    local beta3 = (17 / 480) * Math.Pow(n, 3) - (37 / 840) * Math.Pow(n, 4) - (209 / 4480) * Math.Pow(n, 5) + (5569 / 90720) * Math.Pow(n, 6) + (9261899 / 58060800) * Math.Pow(n, 7) - (6457463 / 17740800) * Math.Pow(n, 8) + (2473691167 / 9289728000) * Math.Pow(n, 9) - (852549456029 / 20922789888000) * Math.Pow(n, 10)
+    local beta4 = (4397 / 161280) * Math.Pow(n, 4) - (11 / 504) * Math.Pow(n, 5) - (830251 / 7257600) * Math.Pow(n, 6) + (466511 / 2494800) * Math.Pow(n, 7) + (324154477 / 7664025600) * Math.Pow(n, 8) - (937932223 / 3891888000) * Math.Pow(n, 9) - (89112264211 / 5230697472000) * Math.Pow(n, 10)
+    local beta5 = (4583 / 161280) * Math.Pow(n, 5) - (108847 / 3991680) * Math.Pow(n, 6) - (8005831 / 63866880) * Math.Pow(n, 7) + (22894433 / 124540416) * Math.Pow(n, 8) + (112731569449 / 557941063680) * Math.Pow(n, 9) - (5391039814733 / 10461394944000) * Math.Pow(n, 10)
+    local beta6 = (20648693 / 638668800) * Math.Pow(n, 6) - (16363163 / 518918400) * Math.Pow(n, 7) - (2204645983 / 12915302400) * Math.Pow(n, 8) + (4543317553 / 18162144000) * Math.Pow(n, 9) + (54894890298749 / 167382319104000) * Math.Pow(n, 10)
+    local beta7 = (219941297 / 5535129600) * Math.Pow(n, 7) - (497323811 / 12454041600) * Math.Pow(n, 8) - (79431132943 / 332107776000) * Math.Pow(n, 9) + (4346429528407 / 12703122432000) * Math.Pow(n, 10)
+    local beta8 = (191773887257 / 3719607091200) * Math.Pow(n, 8) - (17822319343 / 336825216000) * Math.Pow(n, 9) - (497155444501631 / 1422749712384000) * Math.Pow(n, 10)
+    local beta9 = (11025641854267 / 158083301376000) * Math.Pow(n, 9) - (492293158444691 / 6758061133824000) * Math.Pow(n, 10)
+    local beta10 = (7028504530429621 / 72085985427456000) * Math.Pow(n, 10)
 
-    delta1 = 2 * n - (2 / 3) * Math.Pow(n, 2) - 2 * Math.Pow(n, 3)
-    delta2 = (7 / 3) * Math.Pow(n, 2) - (8 / 5) * Math.Pow(n, 3)
-    delta3 = (56 / 15) * Math.Pow(n, 3)
+    local delta1 = 2 * n - (2 / 3) * Math.Pow(n, 2) - 2 * Math.Pow(n, 3)
+    local delta2 = (7 / 3) * Math.Pow(n, 2) - (8 / 5) * Math.Pow(n, 3)
+    local delta3 = (56 / 15) * Math.Pow(n, 3)
 
-    ksi = (Northing / 100 - northernN0) / (k0 * A)
-    eta = (Easting / 100 - E0) / (k0 * A)
+    local ksi = (Northing / 100 - northernN0) / (k0 * A)
+    local eta = (Easting / 100 - E0) / (k0 * A)
 
-    ksi_prime = ksi - (beta1 * Math.Sin(2 * ksi) * Math.Cosh(2 * eta) + beta2 * Math.Sin(4 * ksi) * Math.Cosh(4 * eta) + beta3 * Math.Sin(6 * ksi) * Math.Cosh(6 * eta) + beta4 * Math.Sin(8 * ksi) * Math.Cosh(8 * eta) + beta5 * Math.Sin(10 * ksi) * Math.Cosh(10 * eta) +
-    beta6 * Math.Sin(12 * ksi) * Math.Cosh(12 * eta) + beta7 * Math.Sin(14 * ksi) * Math.Cosh(14 * eta) + beta8 * Math.Sin(16 * ksi) * Math.Cosh(16 * eta) + beta9 * Math.Sin(18 * ksi) * Math.Cosh(18 * eta) + beta10 * Math.Sin(20 * ksi) * Math.Cosh(20 * eta))
+    local ksi_prime = ksi - (beta1 * Math.Sin(2 * ksi) * Math.Cosh(2 * eta) + beta2 * Math.Sin(4 * ksi) * Math.Cosh(4 * eta) +
+            beta3 * Math.Sin(6 * ksi) * Math.Cosh(6 * eta) + beta4 * Math.Sin(8 * ksi) * Math.Cosh(8 * eta) +
+            beta5 * Math.Sin(10 * ksi) * Math.Cosh(10 * eta) + beta6 * Math.Sin(12 * ksi) * Math.Cosh(12 * eta) +
+            beta7 * Math.Sin(14 * ksi) * Math.Cosh(14 * eta) + beta8 * Math.Sin(16 * ksi) * Math.Cosh(16 * eta) +
+            beta9 * Math.Sin(18 * ksi) * Math.Cosh(18 * eta) + beta10 * Math.Sin(20 * ksi) * Math.Cosh(20 * eta))
 
-    eta_prime = eta - (beta1 * Math.Cos(2 * ksi) * Math.Sinh(2 * eta) + beta2 * Math.Cos(4 * ksi) * Math.Sinh(4 * eta) + beta3 * Math.Cos(6 * ksi) * Math.Sinh(6 * eta))
-    sigma_prime = 1 - (2 * beta1 * Math.Cos(2 * ksi) * Math.Cosh(2 * eta) + 2 * beta2 * Math.Cos(4 * ksi) * Math.Cosh(4 * eta) + 2 * beta3 * Math.Cos(6 * ksi) * Math.Cosh(6 * eta))
-    taw_prime = 2 * beta1 * Math.Sin(2 * ksi) * Math.Sinh(2 * eta) + 2 * beta2 * Math.Sin(4 * ksi) * Math.Sinh(4 * eta) + 2 * beta3 * Math.Sin(6 * ksi) * Math.Sinh(6 * eta)
+    local eta_prime = eta - (beta1 * Math.Cos(2 * ksi) * Math.Sinh(2 * eta) + beta2 * Math.Cos(4 * ksi) * Math.Sinh(4 * eta) + beta3 * Math.Cos(6 * ksi) * Math.Sinh(6 * eta))
+    local sigma_prime = 1 - (2 * beta1 * Math.Cos(2 * ksi) * Math.Cosh(2 * eta) + 2 * beta2 * Math.Cos(4 * ksi) * Math.Cosh(4 * eta) + 2 * beta3 * Math.Cos(6 * ksi) * Math.Cosh(6 * eta))
+    local taw_prime = 2 * beta1 * Math.Sin(2 * ksi) * Math.Sinh(2 * eta) + 2 * beta2 * Math.Sin(4 * ksi) * Math.Sinh(4 * eta) + 2 * beta3 * Math.Sin(6 * ksi) * Math.Sinh(6 * eta)
 
-    ki = Math.Asin(Math.Sin(ksi_prime) / Math.Cosh(eta_prime))
+    local ki = Math.Asin(Math.Sin(ksi_prime) / Math.Cosh(eta_prime))
 
-    latitude = (ki + delta1 * Math.Sin(2 * ki) + delta2 * Math.Sin(4 * ki) + delta3 * Math.Sin(6 * ki)) * RtoD
+    local latitude = (ki + delta1 * Math.Sin(2 * ki) + delta2 * Math.Sin(4 * ki) + delta3 * Math.Sin(6 * ki)) * RtoD
 
-    longitude0 = Zone * 6 * DtoR  - 183 * DtoR
-    longitude = (longitude0 + Math.Atan(Math.Sinh(eta_prime) / Math.Cos(ksi_prime))) * RtoD
-
+    local longitude0 = Zone * 6 * DtoR - 183 * DtoR
+    local longitude = (longitude0 + Math.Atan(Math.Sinh(eta_prime) / Math.Cos(ksi_prime))) * RtoD
 
     return latitude, longitude
 

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -88,8 +88,7 @@ function Realm.worldToGridSpace(coords)
     return val
 end
 
-function Realm.UTMToLatLong(utmX, utmY, utmZone, latitude, longitude)
-    local isNorthernHemi = false -- TODO: get this from the utmZone
+function Realm.UTMToLatLong(utmX, utmY, utmZone, utmHemisphere)
     local diflat = -00066286966871111111111111111111111111
     local diflon = -0.0003868060578
 
@@ -104,7 +103,7 @@ function Realm.UTMToLatLong(utmX, utmY, utmZone, latitude, longitude)
     local x = utmX - 500000;
 
     local y
-    if (isNorthernHemi) then
+    if (utmHemisphere) then
         y = utmY;
     else
         y = utmY - 10000000;
@@ -115,16 +114,16 @@ function Realm.UTMToLatLong(utmX, utmY, utmZone, latitude, longitude)
     local v = (c / (1 + (e2cuadrada * (cos(lat) ^ 2)) ^ 0.5)) * 0.9996;
     local a = x / v
     local a1 = math.sin(2 * lat)
-    local a2 = a1 * (Math.cos(lat)^2)
+    local a2 = a1 * (Math.cos(lat) ^ 2)
     local j2 = lat + (a1 / 2)
     local j4 = ((3 * j2) + a2) / 4
-    local j6 = ((5 * j4) + (a2 * (Math.cos(lat)^2))) / 3
+    local j6 = ((5 * j4) + (a2 * (Math.cos(lat) ^ 2))) / 3
     local alfa = (3 / 4) * e2cuadrada;
     local beta = (5 / 3) * (alfa ^ 2);
     local gama = (35 / 27) * (alfa ^ 3);
     local bm = 0.9996 * c * (lat - alfa * j2 + beta * j4 - gama * j6)
     local b = (y - bm) / v
-    local epsi = ((e2cuadrada * (a^2)) / 2) * (math.cos(lat) ^ 2)
+    local epsi = ((e2cuadrada * (a ^ 2)) / 2) * (math.cos(lat) ^ 2)
     local eps = a * (1 - (epsi / 3))
     local nab = (b * (1 - epsi)) + lat
     local senoheps = (math.exp(eps) - math.exp(-eps)) / 2
@@ -132,7 +131,12 @@ function Realm.UTMToLatLong(utmX, utmY, utmZone, latitude, longitude)
     local tao = math.atan(math.cos(delt) * math.tan(nab))
 
     local longitude = ((delt * (180 / math.pi)) + s) + diflon
-    local latitude = (lat + (1 + e2cuadrada * (math.cos(lat)^2) - (3.0/2.0)*e2cuadrada*math.sin(lat)*math.cos(lat)*(tao-lat)) * (tao - lat)) * (180/math.pi) + diflat
+    local latitude = (lat + (1 + e2cuadrada * (math.cos(lat) ^ 2) - (3.0 / 2.0) * e2cuadrada * math.sin(lat) * math.cos(lat) * (tao - lat)) * (tao - lat)) * (180 / math.pi) + diflat
+
+    return {
+        x = longitude,
+        y = latitude
+    }
 
 end
 

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -73,14 +73,10 @@ end
 ---@param coords table coordinates in worldspace
 ---@return table coordinates in gridspace.
 function Realm.worldToGridSpace(coords)
-    Debug.logCoords(coords, "worldToGridSpaceStart")
-
     local val = { x = 0, y = 0, z = 0 }
     val.x = math.ceil((tonumber(coords.x) + Realm.const.worldSize) / 80)
     val.y = math.ceil((tonumber(coords.y) + Realm.const.worldSize) / 80)
     val.z = math.ceil((tonumber(coords.z) + Realm.const.worldSize) / 80)
-
-    Debug.logCoords(val, "worldToGridSpaceEnd")
     return val
 end
 

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -94,137 +94,83 @@ function Realm:WorldToLatLong(position)
 
     local position = self:WorldToUTM(position)
 
-    local latlongPosition = Realm.UTMToLatLong(position.x, position.z, utmInfo.zone, utmInfo.northernHemisphere)
+    local latlongPosition = Realm.UTMToLatLong(position.x, position.z, utmInfo.zone, utmInfo.utm_is_north)
 
     return { x = latlongPosition.latitude, y = position.y, z = latlongPosition.longitude }
 end
 
 
 
--- The following two methods are taken from the following StackOverflow post: https://stackoverflow.com/questions/2689836/converting-utm-wsg84-coordinates-to-latitude-and-longitude
--- First method by: Playful https://stackoverflow.com/users/2255765/playful
--- Second method by: Mohammed Sadeq https://stackoverflow.com/users/7780768/mohammed-sadeq-ale-isaac
+-- The following method is adapted from the following StackOverflow post: https://stackoverflow.com/questions/2689836/converting-utm-wsg84-coordinates-to-latitude-and-longitude
+-- Method originally by: Playful https://stackoverflow.com/users/2255765/playful
 
 
---[[
+function Realm.UTMToLatLong(utmX, utmY, zone, isNorthHemisphere)
 
-function Realm.UTMToLatLong(utmX, utmY, utmZone, utmHemisphere)
-    local diflat = -0.00066286966871111111111111111111111111;
-    local diflon = -0.0003868060578;
+    -- Caching our Math variables for better performance
+    local Math = { }
+    Math.PI = math.pi
+    Math.Pow = math.pow
+    Math.Exp = math.exp
+    Math.Sin = math.sin
+    Math.Cos = math.cos
+    Math.Tan = math.tan
+    Math.Asin = math.asin
+    Math.Atan = math.atan
+    Math.Cosh = math.cosh
+    Math.Sinh = math.sinh
+    Math.Tanh = math.tanh
 
-    local zone = tonumber(utmZone)
 
-    local c_sa = 6378137.000000;
-    local c_sb = 6356752.314245;
+    local diflat = -0.00066286966871111111111111111111111111
+    local diflon = -0.0003868060578
+    local c_sa = 6378137.000000
+    local c_sb = 6356752.314245
 
-    local e2 = ((c_sa ^ 2 - c_sb ^ 2) ^ 0.5) / c_sb;
-    local e2cuadrada = e2 ^ 2;
-    local c = c_sa ^ 2 / c_sb;
-    local x = utmX - 500000;
-
-    local y
-    if (utmHemisphere) then
-        y = utmY;
+    local e2 = Math.Pow((Math.Pow(c_sa, 2) - Math.Pow(c_sb, 2)), 0.5) / c_sb
+    local e2cuadrada = Math.Pow(e2, 2)
+    local c = Math.Pow(c_sa, 2) / c_sb
+    local x = utmX - 500000
+    local y = utmY
+    if (isNorthHemisphere) then
+        y = utmY
     else
-        y = utmY - 10000000;
+        y = utmY - 10000000
     end
 
-    local s = (zone * 6) - 183
-    local lat = y / (c_sa * 0.9996);
-    local v = (c / (1 + (e2cuadrada * (math.cos(lat) ^ 2)) ^ 0.5)) * 0.9996;
+    local s = ((zone * 6.0) - 183.0)
+    local lat = y / (c_sa * 0.9996)
+    local v = (c / Math.Pow(1 + (e2cuadrada * Math.Pow(Math.Cos(lat), 2)), 0.5)) * 0.9996
+
     local a = x / v
-    local a1 = math.sin(2 * lat)
-    local a2 = a1 * (math.cos(lat) ^ 2)
-    local j2 = lat + (a1 / 2)
-    local j4 = ((3 * j2) + a2) / 4
-    local j6 = ((5 * j4) + (a2 * (math.cos(lat) ^ 2))) / 3
-    local alfa = (3 / 4) * e2cuadrada;
-    local beta = (5 / 3) * (alfa ^ 2);
-    local gama = (35 / 27) * (alfa ^ 3);
+    local a1 = Math.Sin(2 * lat)
+    local a2 = a1 * Math.Pow((Math.Cos(lat)), 2)
+
+    local j2 = lat + (a1 / 2.0)
+    local j4 = ((3 * j2) + a2) / 4.0
+    local j6 = ((5 * j4) + Math.Pow(a2 * (Math.Cos(lat)), 2)) / 3.0
+
+    local alfa = (3.0 / 4.0) * e2cuadrada
+    local beta = (5.0 / 3.0) * Math.Pow(alfa, 2)
+    local gama = (35.0 / 27.0) * Math.Pow(alfa, 3)
+
     local bm = 0.9996 * c * (lat - alfa * j2 + beta * j4 - gama * j6)
     local b = (y - bm) / v
-    local epsi = ((e2cuadrada * (a ^ 2)) / 2) * (math.cos(lat) ^ 2)
-    local eps = a * (1 - (epsi / 3))
+    local epsi = ((e2cuadrada * Math.Pow(a, 2)) / 2.0) * Math.Pow((Math.Cos(lat)), 2)
+    local eps = a * (1 - (epsi / 3.0))
     local nab = (b * (1 - epsi)) + lat
-    local senoheps = (math.exp(eps) - math.exp(-eps)) / 2
-    local delt = math.atan(senoheps / (math.cos(nab)))
+    local senoheps = (Math.Exp(eps) - Math.Exp(-eps)) / 2.0
+    local delt = Math.Atan(senoheps / (Math.Cos(nab)))
+    local tao = Math.Atan(Math.Cos(delt) * Math.Tan(nab))
 
-    local tao = math.atan(math.cos(delt) * math.tan(nab))
-
-    local longitude = ((delt * (180 / math.pi)) + s) + diflon
-    local latitude = ((lat + (1 + e2cuadrada * math.pow(math.cos(lat), 2) - (3.0 / 2.0) * e2cuadrada * math.sin(lat) * math.cos(lat) * (tao - lat)) * (tao - lat)) * (180.0 / math.pi)) + diflat;
+    local longitude = mc_helpers.round(((delt * (180.0 / Math.PI)) + s) + diflon,5)
+    local latitude = mc_helpers.round(((lat + (1 + e2cuadrada * Math.Pow(Math.Cos(lat), 2) - (3.0 / 2.0) * e2cuadrada * Math.Sin(lat) * Math.Cos(lat) * (tao - lat)) * (tao - lat)) * (180.0 / Math.PI)) + diflat,5)
 
     return {
         longitude = longitude,
         latitude = latitude
     }
 end
-]]--
-
-function Realm.UTMToLatLong(Easting, Northing, Zone, Hemisphere)
-    local DtoR = math.pi / 180
-    local RtoD = 180 / math.pi;
-
-    local a = 6378137
-    local f = 0.00335281066474748071984552861852
-    local northernN0 = 0
-    local southernN0 = 10000000
-    local E0 = 500000
-
-    -- Caching our Math variables for better performance
-    local Math = { }
-    Math.Pow = math.pow
-    Math.Sin = math.sin
-    Math.Cos = math.cos
-    Math.Asin = math.asin
-    Math.Atan = math.atan
-    Math.Cosh = math.cosh
-    Math.Sinh = math.sinh
-
-    local n = f / (2 - f)
-    local k0 = 0.9996
-    local A = a * (1 + (1 / 4) * Math.Pow(n, 2) + (1 / 64) * Math.Pow(n, 4) + (1 / 256) * Math.Pow(n, 6) + (25 / 16384) * Math.Pow(n, 8) + (49 / 65536) * Math.Pow(n, 10)) / (1 + n)
-
-    local beta1 = n / 2 - (2 / 3) * Math.Pow(n, 2) + (37 / 96) * Math.Pow(n, 3) - (1 / 360) * Math.Pow(n, 4) - (81 / 512) * Math.Pow(n, 5) + (96199 / 604800) * Math.Pow(n, 6) - (5406467 / 38707200) * Math.Pow(n, 7) + (7944359 / 67737600) * Math.Pow(n, 8) - (7378753979 / 97542144000) * Math.Pow(n, 9) + (25123531261 / 804722688000) * Math.Pow(n, 10)
-    local beta2 = (1 / 48) * Math.Pow(n, 2) + (1 / 15) * Math.Pow(n, 3) - (437 / 1440) * Math.Pow(n, 4) + (46 / 105) * Math.Pow(n, 5) - (1118711 / 3870720) * Math.Pow(n, 6) + (51841 / 1209600) * Math.Pow(n, 7) + (24749483 / 348364800) * Math.Pow(n, 8) - (115295683 / 1397088000) * Math.Pow(n, 9) + (5487737251099 / 51502252032000) * Math.Pow(n, 10)
-    local beta3 = (17 / 480) * Math.Pow(n, 3) - (37 / 840) * Math.Pow(n, 4) - (209 / 4480) * Math.Pow(n, 5) + (5569 / 90720) * Math.Pow(n, 6) + (9261899 / 58060800) * Math.Pow(n, 7) - (6457463 / 17740800) * Math.Pow(n, 8) + (2473691167 / 9289728000) * Math.Pow(n, 9) - (852549456029 / 20922789888000) * Math.Pow(n, 10)
-    local beta4 = (4397 / 161280) * Math.Pow(n, 4) - (11 / 504) * Math.Pow(n, 5) - (830251 / 7257600) * Math.Pow(n, 6) + (466511 / 2494800) * Math.Pow(n, 7) + (324154477 / 7664025600) * Math.Pow(n, 8) - (937932223 / 3891888000) * Math.Pow(n, 9) - (89112264211 / 5230697472000) * Math.Pow(n, 10)
-    local beta5 = (4583 / 161280) * Math.Pow(n, 5) - (108847 / 3991680) * Math.Pow(n, 6) - (8005831 / 63866880) * Math.Pow(n, 7) + (22894433 / 124540416) * Math.Pow(n, 8) + (112731569449 / 557941063680) * Math.Pow(n, 9) - (5391039814733 / 10461394944000) * Math.Pow(n, 10)
-    local beta6 = (20648693 / 638668800) * Math.Pow(n, 6) - (16363163 / 518918400) * Math.Pow(n, 7) - (2204645983 / 12915302400) * Math.Pow(n, 8) + (4543317553 / 18162144000) * Math.Pow(n, 9) + (54894890298749 / 167382319104000) * Math.Pow(n, 10)
-    local beta7 = (219941297 / 5535129600) * Math.Pow(n, 7) - (497323811 / 12454041600) * Math.Pow(n, 8) - (79431132943 / 332107776000) * Math.Pow(n, 9) + (4346429528407 / 12703122432000) * Math.Pow(n, 10)
-    local beta8 = (191773887257 / 3719607091200) * Math.Pow(n, 8) - (17822319343 / 336825216000) * Math.Pow(n, 9) - (497155444501631 / 1422749712384000) * Math.Pow(n, 10)
-    local beta9 = (11025641854267 / 158083301376000) * Math.Pow(n, 9) - (492293158444691 / 6758061133824000) * Math.Pow(n, 10)
-    local beta10 = (7028504530429621 / 72085985427456000) * Math.Pow(n, 10)
-
-    local delta1 = 2 * n - (2 / 3) * Math.Pow(n, 2) - 2 * Math.Pow(n, 3)
-    local delta2 = (7 / 3) * Math.Pow(n, 2) - (8 / 5) * Math.Pow(n, 3)
-    local delta3 = (56 / 15) * Math.Pow(n, 3)
-
-    local ksi = (Northing / 100 - northernN0) / (k0 * A)
-    local eta = (Easting / 100 - E0) / (k0 * A)
-
-    local ksi_prime = ksi - (beta1 * Math.Sin(2 * ksi) * Math.Cosh(2 * eta) + beta2 * Math.Sin(4 * ksi) * Math.Cosh(4 * eta) +
-            beta3 * Math.Sin(6 * ksi) * Math.Cosh(6 * eta) + beta4 * Math.Sin(8 * ksi) * Math.Cosh(8 * eta) +
-            beta5 * Math.Sin(10 * ksi) * Math.Cosh(10 * eta) + beta6 * Math.Sin(12 * ksi) * Math.Cosh(12 * eta) +
-            beta7 * Math.Sin(14 * ksi) * Math.Cosh(14 * eta) + beta8 * Math.Sin(16 * ksi) * Math.Cosh(16 * eta) +
-            beta9 * Math.Sin(18 * ksi) * Math.Cosh(18 * eta) + beta10 * Math.Sin(20 * ksi) * Math.Cosh(20 * eta))
-
-    local eta_prime = eta - (beta1 * Math.Cos(2 * ksi) * Math.Sinh(2 * eta) + beta2 * Math.Cos(4 * ksi) * Math.Sinh(4 * eta) + beta3 * Math.Cos(6 * ksi) * Math.Sinh(6 * eta))
-    local sigma_prime = 1 - (2 * beta1 * Math.Cos(2 * ksi) * Math.Cosh(2 * eta) + 2 * beta2 * Math.Cos(4 * ksi) * Math.Cosh(4 * eta) + 2 * beta3 * Math.Cos(6 * ksi) * Math.Cosh(6 * eta))
-    local taw_prime = 2 * beta1 * Math.Sin(2 * ksi) * Math.Sinh(2 * eta) + 2 * beta2 * Math.Sin(4 * ksi) * Math.Sinh(4 * eta) + 2 * beta3 * Math.Sin(6 * ksi) * Math.Sinh(6 * eta)
-
-    local ki = Math.Asin(Math.Sin(ksi_prime) / Math.Cosh(eta_prime))
-
-    local latitude = (ki + delta1 * Math.Sin(2 * ki) + delta2 * Math.Sin(4 * ki) + delta3 * Math.Sin(6 * ki)) * RtoD
-
-    local longitude0 = Zone * 6 * DtoR - 183 * DtoR
-    local longitude = (longitude0 + Math.Atan(Math.Sinh(eta_prime) / Math.Cos(ksi_prime))) * RtoD
-
-    return latitude, longitude
-
-end
-
-
 
 
 

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -23,13 +23,43 @@ end
 function Realm:LocalToUTM(position)
     local utmInfo = self:get_data("utmInfo")
 
-    return position
+    if (utmInfo == nil) then
+        utmInfo = {}
+        utmInfo.easting = 0
+        utmInfo.northing = 0
+    end
+
+    local x = position.x + utmInfo.easting
+    local z = position.z + utmInfo.northing
+
+    return {
+        x = math.floor(x),
+        y = math.floor(position.y),
+        z = math.floor(z)
+    }
+end
+
+function Realm:WorldToUTM(position)
+    return self:LocalToUTM(self:WorldToLocalPosition(position))
 end
 
 function Realm:UTMToLocal(position)
     local utmInfo = self:get_data("utmInfo")
 
-    return position
+    if (utmInfo == nil) then
+        utmInfo = {}
+        utmInfo.easting = 0
+        utmInfo.northing = 0
+    end
+
+    local x = position.x - utmInfo.easting
+    local z = position.z - utmInfo.northing
+
+    return {
+        x = x,
+        y = position.y,
+        z = z
+    }
 end
 
 ---gridToWorldSpace
@@ -57,3 +87,55 @@ function Realm.worldToGridSpace(coords)
     Debug.logCoords(val, "worldToGridSpaceEnd")
     return val
 end
+
+function Realm.UTMToLatLong(utmX, utmY, utmZone, latitude, longitude)
+    local isNorthernHemi = false -- TODO: get this from the utmZone
+    local diflat = -00066286966871111111111111111111111111
+    local diflon = -0.0003868060578
+
+    local zone = tonumber(utmZone) -- TODO
+
+    local c_sa = 6378137.000000;
+    local c_sb = 6356752.314245;
+
+    local e2 = ((c_sa ^ 2 - c_sb ^ 2) ^ 0.5) / c_sb;
+    local e2cuadrada = e2 ^ 2;
+    local c = c_sa ^ 2 / c_sb;
+    local x = utmX - 500000;
+
+    local y
+    if (isNorthernHemi) then
+        y = utmY;
+    else
+        y = utmY - 10000000;
+    end
+
+    local s = (zone * 6) - 183
+    local lat = y / (c_sa * 0.9996);
+    local v = (c / (1 + (e2cuadrada * (cos(lat) ^ 2)) ^ 0.5)) * 0.9996;
+    local a = x / v
+    local a1 = math.sin(2 * lat)
+    local a2 = a1 * (Math.cos(lat)^2)
+    local j2 = lat + (a1 / 2)
+    local j4 = ((3 * j2) + a2) / 4
+    local j6 = ((5 * j4) + (a2 * (Math.cos(lat)^2))) / 3
+    local alfa = (3 / 4) * e2cuadrada;
+    local beta = (5 / 3) * (alfa ^ 2);
+    local gama = (35 / 27) * (alfa ^ 3);
+    local bm = 0.9996 * c * (lat - alfa * j2 + beta * j4 - gama * j6)
+    local b = (y - bm) / v
+    local epsi = ((e2cuadrada * (a^2)) / 2) * (math.cos(lat) ^ 2)
+    local eps = a * (1 - (epsi / 3))
+    local nab = (b * (1 - epsi)) + lat
+    local senoheps = (math.exp(eps) - math.exp(-eps)) / 2
+    local delt = math.atan(senoheps / (math.cos(nab)))
+    local tao = math.atan(math.cos(delt) * math.tan(nab))
+
+    local longitude = ((delt * (180 / math.pi)) + s) + diflon
+    local latitude = (lat + (1 + e2cuadrada * (math.cos(lat)^2) - (3.0/2.0)*e2cuadrada*math.sin(lat)*math.cos(lat)*(tao-lat)) * (tao - lat)) * (180/math.pi) + diflat
+
+end
+
+
+
+

--- a/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
+++ b/mods/mc_worldmanager/realm/realmCoordinateConversion.lua
@@ -20,6 +20,18 @@ function Realm:WorldToLocalPosition(position)
     return pos
 end
 
+function Realm:LocalToUTM(position)
+    local utmInfo = self:get_data("utmInfo")
+
+    return position
+end
+
+function Realm:UTMToLocal(position)
+    local utmInfo = self:get_data("utmInfo")
+
+    return position
+end
+
 ---gridToWorldSpace
 ---@param coords table coordinates in gridspace
 ---@return table coordinates in worldspace
@@ -43,6 +55,5 @@ function Realm.worldToGridSpace(coords)
     val.z = math.ceil((tonumber(coords.z) + Realm.const.worldSize) / 80)
 
     Debug.logCoords(val, "worldToGridSpaceEnd")
-
     return val
 end

--- a/mods/mc_worldmanager/realm/realmPlayerManagement.lua
+++ b/mods/mc_worldmanager/realm/realmPlayerManagement.lua
@@ -26,7 +26,7 @@ function Realm:TeleportPlayer(player)
     player:set_pos(spawn)
 
     self:RegisterPlayer(player)
-    mc_worldManager.updateHud(player)
+    mc_worldManager.UpdateRealmHud(player)
     self:ApplyPrivileges(player)
 
     return true, "Successfully teleported to realm."

--- a/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
+++ b/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
@@ -118,6 +118,9 @@ function Realm:Load_Schematic(schematic, config)
         self.EndPos = schematicEndPos
     end
 
+    if (config.utmInfo ~= nil) then
+        self:set_data("UTMInfo", config.utmInfo)
+    end
 
 
 
@@ -182,11 +185,6 @@ function Realm:Load_Schematic(schematic, config)
         if (config.onRealmDeleteFunction ~= nil) then
             table.insert(self.RealmDeleteTable, { tableName = config.tableName, functionName = config.onRealmDeleteFunction })
         end
-
-        if (config.utmInfo ~= nil) then
-            self:set_data("UTMInfo", config.utmInfo)
-        end
-
 
     end
 

--- a/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
+++ b/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
@@ -67,6 +67,16 @@ function Realm:Save_Schematic(schematicName, author, mode)
     settings:set("schematic_size_y", self.EndPos.y - self.StartPos.y)
     settings:set("schematic_size_z", self.EndPos.z - self.StartPos.z)
 
+
+    local utmInfo = self:get_data("UTMInfo")
+
+    if (utmInfo ~= nil) then
+        settings:set("utm_zone", utmInfo.zone)
+        settings:set("utm_easting", utmInfo.easting)
+        settings:set("utm_northing", utmInfo.northing)
+    end
+
+
     local settingsWrote = settings:write()
 
     if (settingsWrote == false) then
@@ -172,6 +182,12 @@ function Realm:Load_Schematic(schematic, config)
         if (config.onRealmDeleteFunction ~= nil) then
             table.insert(self.RealmDeleteTable, { tableName = config.tableName, functionName = config.onRealmDeleteFunction })
         end
+
+        if (config.utmInfo ~= nil) then
+            self:set_data("UTMInfo", config.utmInfo)
+        end
+
+
     end
 
     self:UpdateSpawn(config.spawnPoint)

--- a/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
+++ b/mods/mc_worldmanager/realm/realmSchematicSaveLoad.lua
@@ -95,7 +95,7 @@ end
 function Realm:Load_Schematic(schematic, config)
 
     --TODO: Add code to check if the realm is large enough to support the schematic; If not, create a new realm that can;
-    local schematicEndPos = self:LocalToWorldPosition(config.schematicSize)
+    local schematicEndPos = self:LocalToWorldSpace(config.schematicSize)
 
     if (schematicEndPos.x > self.EndPos.x or schematicEndPos.y > self.EndPos.y or schematicEndPos.z > self.EndPos.z) then
         Debug.log("Schematic is too large for realm")

--- a/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
+++ b/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
@@ -83,5 +83,5 @@ function Realm:GenerateTerrain(seed, seaLevel, heightMapGeneratorName, mapDecora
     local oldSpawnPos = self.SpawnPoint
     local surfaceLevel = ptable.get2D(heightMapTable, { x = oldSpawnPos.x, y = oldSpawnPos.z })
 
-    self:UpdateSpawn(self:WorldToLocalPosition({ x = oldSpawnPos.x, y = surfaceLevel, z = oldSpawnPos.z }))
+    self:UpdateSpawn(self:WorldToLocalSpace({ x = oldSpawnPos.x, y = surfaceLevel, z = oldSpawnPos.z }))
 end

--- a/mods/mc_worldmanager/schematicmanager.lua
+++ b/mods/mc_worldmanager/schematicmanager.lua
@@ -78,15 +78,24 @@ function schematicManager.getSchematic(key)
     local realm_create_function_name = settings:get("realm_create_function_name") or nil
     local realm_delete_function_name = settings:get("realm_delete_function_name") or nil
 
+    local utm_zone = settings:get("utm_zone") or 1
+    local utm_origin_easting = tonumber(settings:get("utm_easting")) or 0
+    local utm_origin_northing = tonumber(settings:get("utm_northing")) or 0
+
     local _spawnPoint = { x = spawn_pos_x, y = spawn_pos_y, z = spawn_pos_z }
     local _schematicSize = { x = schematic_size_x, y = schematic_size_y, z = schematic_size_z }
+    local _utmInfo = { zone = utm_zone, easting = utm_origin_easting, northing = utm_origin_northing }
 
     local config = { author = _author, name = _name, format = _format, spawnPoint = _spawnPoint, schematicSize = _schematicSize,
                      tableName = schematic_table_name, onTeleportInFunction = teleport_function_in_name, onTeleportOutFunction = teleport_function_out_name,
-                     onSchematicPlaceFunction = realm_create_function_name, onRealmDeleteFunction = realm_delete_function_name }
+                     onSchematicPlaceFunction = realm_create_function_name, onRealmDeleteFunction = realm_delete_function_name, utmInfo = _utmInfo }
 
     return schematic, config
 end
+
+
+
+
 
 
 -- Scan the world realm schematics folder and add them to the schematics list.

--- a/mods/mc_worldmanager/schematicmanager.lua
+++ b/mods/mc_worldmanager/schematicmanager.lua
@@ -78,7 +78,7 @@ function schematicManager.getSchematic(key)
     local realm_create_function_name = settings:get("realm_create_function_name") or nil
     local realm_delete_function_name = settings:get("realm_delete_function_name") or nil
 
-    local utm_zone = settings:get("utm_zone") or 1
+    local utm_zone = tonumber(settings:get("utm_zone") or 1)
     local utm_hemisphere = settings:get("utm_hemisphere") or "N"
     local utm_origin_easting = tonumber(settings:get("utm_origin_easting")) or 0
     local utm_origin_northing = tonumber(settings:get("utm_origin_northing")) or 0

--- a/mods/mc_worldmanager/schematicmanager.lua
+++ b/mods/mc_worldmanager/schematicmanager.lua
@@ -79,12 +79,13 @@ function schematicManager.getSchematic(key)
     local realm_delete_function_name = settings:get("realm_delete_function_name") or nil
 
     local utm_zone = settings:get("utm_zone") or 1
-    local utm_origin_easting = tonumber(settings:get("utm_easting")) or 0
-    local utm_origin_northing = tonumber(settings:get("utm_northing")) or 0
+    local utm_hemisphere = settings:get("utm_hemisphere") or "N"
+    local utm_origin_easting = tonumber(settings:get("utm_origin_easting")) or 0
+    local utm_origin_northing = tonumber(settings:get("utm_origin_northing")) or 0
 
     local _spawnPoint = { x = spawn_pos_x, y = spawn_pos_y, z = spawn_pos_z }
     local _schematicSize = { x = schematic_size_x, y = schematic_size_y, z = schematic_size_z }
-    local _utmInfo = { zone = utm_zone, easting = utm_origin_easting, northing = utm_origin_northing }
+    local _utmInfo = { zone = utm_zone, utm_is_north = (utm_hemisphere == "n" or utm_hemisphere == "N"), easting = utm_origin_easting, northing = utm_origin_northing }
 
     local config = { author = _author, name = _name, format = _format, spawnPoint = _spawnPoint, schematicSize = _schematicSize,
                      tableName = schematic_table_name, onTeleportInFunction = teleport_function_in_name, onTeleportOutFunction = teleport_function_out_name,


### PR DESCRIPTION
This PR adds the feature request from #77.

- Adds config options to realm schematics to set the UTM zone and eastings/northings of the realm at origin -- local pos: (0,0).
- Adds a command to set the UTM zone and Eastings/Northings values of any existing realm.
- Adds a function to convert from UTM to lat/long pairs
- Adds a toggleable HUD to display player position in either world space, local space, grid space, UTM space, or Latitude/Longitude pairs.
- Adds a realm data command to set and retrieve the arbitrary realm storage values added onto realms 
- Added UTM info to the MKRF config files
