### PR TITLE
fixed remove hud when players leave

### DIFF
--- a/mods/mc_worldmanager/hooks.lua
+++ b/mods/mc_worldmanager/hooks.lua
@@ -43,8 +43,7 @@ end)
 
 -- When player leave the game, we delete their hud
 minetest.register_on_leaveplayer(function(player, timed_out)
-    mc_worldManager.RemoveRealmHud(player)
-    mc_worldManager.RemovePositionHud(player)
+    mc_worldManager.RemoveHud(player)
 
     local realm = Realm.GetRealmFromPlayer(player)
     if (realm:getCategory() == "instanced") then

--- a/mods/mc_worldmanager/hud.lua
+++ b/mods/mc_worldmanager/hud.lua
@@ -35,7 +35,7 @@ function mc_worldManager.UpdateRealmHud(player)
     return true
 end
 
-function mc_worldManager.RemoveRealmHud(player)
+function mc_worldManager.RemoveHud(player)
     mc_worldManager.hud:remove(player)
 end
 
@@ -101,8 +101,4 @@ function mc_worldManager.UpdatePositionHud(player, positionMode)
     })
 
     return true
-end
-
-function mc_worldManager.RemovePositionHud(player)
-    mc_worldManager.hud:remove(player, "worldManager:position")
 end


### PR DESCRIPTION
- Fixed the crash caused by players with positionHUD's enabled leaving the game.
- Unable to replicate the HUD not appearing even when running a dedicated server on Ubuntu 22.04 after making this fix.  