### PR TITLE
Feature/biomegen "frankentree" fix

### DIFF
--- a/mods/biomegen-v1.0/init.lua
+++ b/mods/biomegen-v1.0/init.lua
@@ -52,8 +52,6 @@ local function initialize(chulens, seaLevel, seed)
     nobj_heat = minetest.get_perlin_map(np_heat, chulens2d)
     nobj_heat_blend = minetest.get_perlin_map(noiseparams('mg_biome_np_heat_blend'), chulens2d)
 
-
-
     nobj_humid = minetest.get_perlin_map(np_humidity, chulens2d)
     nobj_humid_blend = minetest.get_perlin_map(noiseparams('mg_biome_np_humidity_blend'), chulens2d)
 
@@ -315,7 +313,7 @@ local function can_place_deco(deco, data, vi, pattern)
     return false
 end
 
-local function place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY)
+local function place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY, placementTable)
     local ps = PcgRandom(blockseed + 53)
     local carea_size = maxp.x - minp.x + 1
 
@@ -442,7 +440,6 @@ local function place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY
                         end
                     end
 
-                --    if y >= (deco.y_min + seaLevel) and y <= (deco.y_max + seaLevel) and y >= minp.y and y <= maxp.y then
                     if y >= (deco.y_min + realmOriginY) and y <= (deco.y_max + realmOriginY) and y >= minp.y and y <= maxp.y then
                         local biome_ok = true
                         if deco.use_biomes and #biomemap > 0 then
@@ -452,11 +449,12 @@ local function place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY
                             end
                         end
 
-                        if biome_ok then
-                            local pos = { x = x, y = y, z = z }
+                        local pos = { x = x, y = y, z = z }
+                        if biome_ok and (ptable.get(placementTable, pos) == nil) then
+
                             if can_place_deco(deco, data, a:index(x, y, z), pattern) then
-                                Debug.log(deco.name .. " at " .. pos.x .. "," .. pos.y .. "," .. pos.z)
                                 deco:generate(vm, ps, pos, false)
+                                ptable.store(placementTable, pos, true)
                             end
                         end
                     end
@@ -476,10 +474,12 @@ local function place_all_decos(data, a, vm, minp, maxp, seed, realmOriginY)
     local emin = vm:get_emerged_area()
     local blockseed = get_blockseed(emin, seed)
 
+    local placementTable = {}
+
     local nplaced = 0
 
     for i, deco in pairs(decos) do
-        nplaced = nplaced + place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY)
+        nplaced = nplaced + place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY, placementTable)
     end
 
     return nplaced

--- a/mods/biomegen-v1.0/init.lua
+++ b/mods/biomegen-v1.0/init.lua
@@ -315,7 +315,7 @@ local function can_place_deco(deco, data, vi, pattern)
     return false
 end
 
-local function place_deco(deco, data, a, vm, minp, maxp, blockseed, seaLevel)
+local function place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY)
     local ps = PcgRandom(blockseed + 53)
     local carea_size = maxp.x - minp.x + 1
 
@@ -442,7 +442,8 @@ local function place_deco(deco, data, a, vm, minp, maxp, blockseed, seaLevel)
                         end
                     end
 
-                    if y >= (deco.y_min + seaLevel) and y <= (deco.y_max + seaLevel) and y >= minp.y and y <= maxp.y then
+                --    if y >= (deco.y_min + seaLevel) and y <= (deco.y_max + seaLevel) and y >= minp.y and y <= maxp.y then
+                    if y >= (deco.y_min + realmOriginY) and y <= (deco.y_max + realmOriginY) and y >= minp.y and y <= maxp.y then
                         local biome_ok = true
                         if deco.use_biomes and #biomemap > 0 then
                             local biome_here = biomemap[mapindex]
@@ -454,6 +455,7 @@ local function place_deco(deco, data, a, vm, minp, maxp, blockseed, seaLevel)
                         if biome_ok then
                             local pos = { x = x, y = y, z = z }
                             if can_place_deco(deco, data, a:index(x, y, z), pattern) then
+                                Debug.log(deco.name .. " at " .. pos.x .. "," .. pos.y .. "," .. pos.z)
                                 deco:generate(vm, ps, pos, false)
                             end
                         end
@@ -470,14 +472,14 @@ local function get_blockseed(p, seed)
     return seed + p.z * 38134234 + p.y * 42123 + p.x * 23
 end
 
-local function place_all_decos(data, a, vm, minp, maxp, seed, seaLevel)
+local function place_all_decos(data, a, vm, minp, maxp, seed, realmOriginY)
     local emin = vm:get_emerged_area()
     local blockseed = get_blockseed(emin, seed)
 
     local nplaced = 0
 
     for i, deco in pairs(decos) do
-        nplaced = nplaced + place_deco(deco, data, a, vm, minp, maxp, blockseed, seaLevel)
+        nplaced = nplaced + place_deco(deco, data, a, vm, minp, maxp, blockseed, realmOriginY)
     end
 
     return nplaced
@@ -562,10 +564,10 @@ biomegen = {
     dust_top_nodes = dust_top_nodes,
 }
 
-function biomegen.generate_all(data, a, vm, minp, maxp, seed, seaLevel)
+function biomegen.generate_all(data, a, vm, minp, maxp, seed, seaLevel, realmOriginY)
     generate_biomes(data, a, minp, maxp, seed, seaLevel)
     vm:set_data(data)
-    place_all_decos(data, a, vm, minp, maxp, seed, seaLevel)
+    place_all_decos(data, a, vm, minp, maxp, seed, realmOriginY)
     minetest.generate_ores(vm, minp, maxp)
     vm:get_data(data)
     dust_top_nodes(data, a, vm, minp, maxp, seaLevel)

--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -235,7 +235,7 @@ Realm.WorldGen.RegisterMapDecorator("v2",
 Realm.WorldGen.RegisterMapDecorator("biomegen", function(startPos, endPos, vm, area, data, heightMapTable, seed, seaLevel)
     Debug.log("Calling biomegen map decorator")
     biomegen.set_elevation_chill(0.5)
-    biomegen.generate_all(data, area, vm, startPos, endPos, seed, seaLevel - 2)
+    biomegen.generate_all(data, area, vm, startPos, endPos, seed, seaLevel - 2, startPos.y)
 end)
 
 


### PR DESCRIPTION
This PR fixes #148 

I determined that the map generator was overlapping trees when there was little to no lag during generation. Out of pure speculation, I think this may have been because we were pulling random numbers too quickly in succession. The debug output was slowing down the code enough that this was not happening while trying to debug.

Because I was testing with larger maps than the default realm size for "efficiency" and/or my slow laptop, it was very rare for this to be replicated. As soon as I started working on my desktop, the bug became very apparent.

This PR fixes the issue by keeping track of where decorations are placed and ensuring that large decorations (e.g., trees) are not placed in the exact same location as each other. 