### PR TITLE
Feature/realm dnr terrain generator

### DIFF
--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -39,7 +39,7 @@ Realm.WorldGen.RegisterHeightMapGenerator("v1", function(startPos, endPos, vm, a
                     surfaceHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
                 end
 
-                if (posY < surfaceHeight) then
+                if (posY <= surfaceHeight) then
                     data[vi] = c_stone
                 elseif (posY < seaLevel) then
                     data[vi] = c_water
@@ -95,7 +95,7 @@ Realm.WorldGen.RegisterHeightMapGenerator("v2", function(startPos, endPos, vm, a
                     surfaceHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
                 end
 
-                if (posY < surfaceHeight) then
+                if (posY <= surfaceHeight) then
                     data[vi] = c_stone
                 elseif (posY < seaLevel) then
                     data[vi] = c_water
@@ -168,7 +168,7 @@ Realm.WorldGen.RegisterMapDecorator("v1", function(startPos, endPos, vm, area, d
                         data[vi] = c_dirt
                     end
 
-                    if (posY >= surfaceHeight - 1 and data[vi] == c_dirt) then
+                    if (posY == surfaceHeight and data[vi] == c_dirt) then
                         if (posY <= seaLevel) then
                             data[vi] = c_sand
                             if (data[viBelow] == c_dirt) then
@@ -211,7 +211,7 @@ Realm.WorldGen.RegisterMapDecorator("v2",
                                 data[vi] = c_dirt
                             end
 
-                            if (posY >= surfaceHeight - 1 and data[vi] == c_dirt) then
+                            if (posY == surfaceHeight and data[vi] == c_dirt) then
                                 if (posY <= seaLevel) then
                                     data[vi] = c_sand
                                     if (data[viBelow] == c_dirt) then

--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -105,6 +105,41 @@ Realm.WorldGen.RegisterHeightMapGenerator("v2", function(startPos, endPos, vm, a
     return heightMapTable
 end)
 
+Realm.WorldGen.RegisterHeightMapGenerator("dnr", function(startPos, endPos, vm, area, data, seed, realmFloorLevel, seaLevel)
+    Debug.log("Calling heightmap generator DNR")
+
+    local heightMapTable = {}
+
+    for posZ = startPos.z, endPos.z do
+        for posY = startPos.y, endPos.y do
+            for posX = startPos.x, endPos.x do
+
+                local vi = area:index(posX, posY, posZ)
+                if (data[vi] ~= c_water and data[vi] ~= c_air) then
+                    data[vi] = c_stone
+
+                    local previousHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
+
+                    if (previousHeight == nil) then
+                        previousHeight = realmFloorLevel
+                    end
+
+                    if (posY > previousHeight) then
+                        ptable.store2D(heightMapTable, { x = posX, y = posZ }, posY)
+                    end
+                end
+
+                if (data[vi] ~= c_stone and posY <= seaLevel) then
+                    data[vi] = c_water
+                end
+            end
+        end
+
+    end
+
+    return heightMapTable
+end)
+
 Realm.WorldGen.RegisterMapDecorator("v1", function(startPos, endPos, vm, area, data, heightMapTable, seed, seaLevel)
     Debug.log("Calling map decorator v1")
 

--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -127,9 +127,9 @@ Realm.WorldGen.RegisterHeightMapGenerator("dnr", function(startPos, endPos, vm, 
 
                 local vi = area:index(posX, posY, posZ)
 
-                if (data[vi] == c_barrierAir or data[vi] == c_barrierGround or data[vi] == c_barrierSolid) then
+                if (data[vi] == c_barrierAir or data[vi] == c_barrierGround or data[vi] == c_barrierSolid or data[vi] == c_water) then
                     data[vi] = c_air
-                elseif (data[vi] ~= c_water and data[vi] ~= c_air) then
+                elseif (data[vi] ~= c_air) then
                     data[vi] = c_stone
 
                     if (posY > previousHeight) then

--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -164,11 +164,11 @@ Realm.WorldGen.RegisterMapDecorator("v1", function(startPos, endPos, vm, area, d
 
                 if (data[vi] == c_stone) then
                     local surfaceHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
-                    if (posY > surfaceHeight - ((1 - erosionPerlin:get_2d({ x = posX, y = posZ })) * 5)) then
+                    if (posY >= surfaceHeight - ((1 - erosionPerlin:get_2d({ x = posX, y = posZ })) * 5)) then
                         data[vi] = c_dirt
                     end
 
-                    if (posY >= surfaceHeight and data[vi] == c_dirt) then
+                    if (posY >= surfaceHeight - 1 and data[vi] == c_dirt) then
                         if (posY <= seaLevel) then
                             data[vi] = c_sand
                             if (data[viBelow] == c_dirt) then
@@ -207,11 +207,11 @@ Realm.WorldGen.RegisterMapDecorator("v2",
                             local fertilityNoise = fertilityPerlin:get_2d({ x = posX, y = posZ })
 
                             local surfaceHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
-                            if (posY > surfaceHeight - ((1 - erosionNoise) * 5)) then
+                            if (posY >= surfaceHeight - ((1 - erosionNoise) * 5)) then
                                 data[vi] = c_dirt
                             end
 
-                            if (posY >= surfaceHeight and data[vi] == c_dirt) then
+                            if (posY >= surfaceHeight - 1 and data[vi] == c_dirt) then
                                 if (posY <= seaLevel) then
                                     data[vi] = c_sand
                                     if (data[viBelow] == c_dirt) then

--- a/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
+++ b/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
@@ -85,5 +85,5 @@ function Realm:GenerateTerrain(seed, seaLevel, heightMapGeneratorName, mapDecora
     local oldSpawnPos = self.SpawnPoint
     local surfaceLevel = ptable.get2D(heightMapTable, { x = oldSpawnPos.x, y = oldSpawnPos.z })
 
-    self:UpdateSpawn(self:WorldToLocalSpace({ x = oldSpawnPos.x, y = surfaceLevel, z = oldSpawnPos.z }))
+    self:UpdateSpawn(self:WorldToLocalSpace({ x = oldSpawnPos.x, y = surfaceLevel + 1, z = oldSpawnPos.z }))
 end


### PR DESCRIPTION
This PR adds a new terrain generator "dnr" (do not replace). The DNR prepares the existing realm terrain as a heightmap for the decorator. This is useful as it allows us to use schematics such as the MKRF512_slope with different ocean levels, biomes, etc.,

Steps to use:
1. Import terrain schematic that you'd like to use: E.g., `/realm schematic load mkrf512_slope`
2. Generate terrain using the dnr generator, the decorator of your choice, and any optional parameters: E.g., `/realm gen dnr v2`

Example Screenshot of MKRF512_slope with biomegen (seed: 846162855; Sea level: 30)
![image](https://user-images.githubusercontent.com/7264590/183483705-742595fb-006c-4430-bfcd-23d29ee2f46b.png)


