### PR TITLE
Fix/realm gen set spawn crash

### DIFF
--- a/mods/mc_worldmanager/WorldGen.lua
+++ b/mods/mc_worldmanager/WorldGen.lua
@@ -121,7 +121,7 @@ Realm.WorldGen.RegisterHeightMapGenerator("dnr", function(startPos, endPos, vm, 
                 -- Generate a height map from the existing map
                 local previousHeight = ptable.get2D(heightMapTable, { x = posX, y = posZ })
                 if (previousHeight == nil) then
-                    previousHeight = realmFloorLevel
+                    previousHeight = startPos.y
                 end
 
 

--- a/mods/mc_worldmanager/commands.lua
+++ b/mods/mc_worldmanager/commands.lua
@@ -346,13 +346,18 @@ commands["setspawn"] = {
 
         local requestedRealm = Realm.GetRealmFromPlayer(player)
 
-        local position = requestedRealm:WorldToLocalSpace(player:get_pos())
+        local playerPosition = player:get_pos()
 
+        if (not requestedRealm:ContainsCoordinate(playerPosition)) then
+            return false, "You are not physically located in realm" .. tostring(requestedRealm.ID) .. " Please re-enter realm boundaries and try again."
+        end
+
+        local position = requestedRealm:WorldToLocalSpace(playerPosition)
         requestedRealm:UpdateSpawn(position)
 
         return true, "Updated spawnpoint for realm with ID: " .. requestedRealm.ID
     end,
-    help = "realm setspawn <realmID> - Set the spawnpoint of a realm.", }
+    help = "realm setspawn - Set the spawnpoint for the realm that you're currently located.", }
 
 commands["setspawnrealm"] = {
     func = function(name, params)

--- a/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
+++ b/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
@@ -81,12 +81,17 @@ function Realm:GenerateTerrain(seed, seaLevel, heightMapGeneratorName, mapDecora
     end
 
     -- Set our new spawnpoint
-    local oldSpawnPos = self.SpawnPoint
-    local surfaceLevel = ptable.get2D(heightMapTable, { x = oldSpawnPos.x, y = oldSpawnPos.z })
+    local spawnPos = self.SpawnPoint
+    local surfaceLevel = ptable.get2D(heightMapTable, { x = spawnPos.x, y = spawnPos.z })
 
     if (surfaceLevel == nil) then
-        surfaceLevel = self.EndPos.y - 5
+        local spawnPos = { x = (self.StartPos.x + self.EndPos.x) / 2, y = (self.StartPos.y + self.EndPos.y) / 2, z = (self.StartPos.z + self.EndPos.z) / 2 }
+        surfaceLevel = ptable.get2D(heightMapTable, { x = spawnPos.x, y = spawnPos.z })
+
+        if (surfaceLevel == nil) then
+            surfaceLevel = self.EndPos.y - 5
+        end
     end
 
-    self:UpdateSpawn(self:WorldToLocalSpace({ x = oldSpawnPos.x, y = surfaceLevel + 1, z = oldSpawnPos.z }))
+    self:UpdateSpawn(self:WorldToLocalSpace({ x = spawnPos.x, y = surfaceLevel + 1, z = spawnPos.z }))
 end

--- a/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
+++ b/mods/mc_worldmanager/realm/realmTerrainGeneration.lua
@@ -15,17 +15,17 @@ function Realm.WorldGen.RegisterHeightMapGenerator(name, heightMapGeneratorFunct
 end
 
 function Realm.WorldGen.GetHeightmapGenerators()
-    local keyset={}
-    for k,v in pairs(heightMapGenerator) do
-        keyset[#keyset+1]=k
+    local keyset = {}
+    for k, v in pairs(heightMapGenerator) do
+        keyset[#keyset + 1] = k
     end
     return keyset
 end
 
 function Realm.WorldGen.GetTerrainDecorator()
-    local keyset={}
-    for k,v in pairs(MapDecorator) do
-        keyset[#keyset+1]=k
+    local keyset = {}
+    for k, v in pairs(MapDecorator) do
+        keyset[#keyset + 1] = k
     end
     return keyset
 end
@@ -83,6 +83,10 @@ function Realm:GenerateTerrain(seed, seaLevel, heightMapGeneratorName, mapDecora
     -- Set our new spawnpoint
     local oldSpawnPos = self.SpawnPoint
     local surfaceLevel = ptable.get2D(heightMapTable, { x = oldSpawnPos.x, y = oldSpawnPos.z })
+
+    if (surfaceLevel == nil) then
+        surfaceLevel = self.EndPos.y - 5
+    end
 
     self:UpdateSpawn(self:WorldToLocalSpace({ x = oldSpawnPos.x, y = surfaceLevel + 1, z = oldSpawnPos.z }))
 end


### PR DESCRIPTION
Weird Github duplicate branch shenanigans happening forcing a duplicate PR to receive the most up-to-date commit history.

This PR fixes a rare crash that happens when using the DNR heightmap generator when the old spawn point was outside of the terrain generation bounds. 
- Fixed crash caused by trying to use non-existent heightMapTable entries when setting realm spawn during terrain generation.
- Fixed potential incorrect heightMap values if realmFloorLevel is somehow above terrain.
- Updated setSpawn command to ensure that it always sets valid in-realm spawnpoints.
- Added a 2-step spawnpoint fallback when generating new terrain (first fallback step is to try the terrain height at the center of the realm, if this fails, we set the spawnpoint to the center of the realm, 5 blocks below the upper boundary. 