### PR TITLE
`mc_core` compatibility patch

### DIFF
--- a/mods/mc_core/init.lua
+++ b/mods/mc_core/init.lua
@@ -1,6 +1,8 @@
 -- initialize minetest_classroom global object + mod table
 minetest_classroom = {}
 mc_core = {path = minetest.get_modpath("mc_core")}
+-- for compatibility with older mods
+mc_helpers = mc_core
 
 dofile(mc_core.path.."/Debugging.lua")
 dofile(mc_core.path.."/lualzw.lua")


### PR DESCRIPTION
Quick patch to ensure that old versions of mods which rely on `mc_core` (formerly `mc_helpers`) can access helper functions