### PR TITLE
Teacher tool + privilege patches

### DIFF
--- a/mods/mc_teacher/callbacks.lua
+++ b/mods/mc_teacher/callbacks.lua
@@ -448,7 +448,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
             minetest.chat_send_all(minetest.colorize(mc_core.col.log, "[Minetest Classroom] "..fields.servermessage))
 			reload = true
         elseif fields.submitsched then
-            if mc_teacher.restart_scheduled.timer then mc_teacher.restart_scheduled.timer:cancel() end
+            mc_teacher.cancel_shutdown()
             local sched = {
                 ["1 minute"] = 60,
                 ["5 minutes"] = 300,
@@ -458,18 +458,28 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
                 ["1 hour"] = 3600,
                 ["6 hours"] = 21600,
                 ["12 hours"] = 43200,
-                ["24 hours"] = 86400}
+                ["24 hours"] = 86400
+            }
+            local warn = {600, 540, 480, 420, 360, 300, 240, 180, 120, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 4, 3, 2, 1}
+
             local time = sched[fields.time]
-            mc_teacher.restart_scheduled.timer = minetest.after(time,mc_teacher.shutdown_server,true)
+            minetest.chat_send_player(player:get_player_name(), minetest.colorize(mc_core.col.log, "[Minetest Classroom] Server restart successfully scheduled!"))
+            minetest.chat_send_all(minetest.colorize(mc_core.col.log, "[Minetest Classroom] The server will be restarting in "..fields.time..". Worlds will be saved prior to the restart, so world data should not be lost."))
+            mc_teacher.restart_scheduled.timer = minetest.after(time, mc_teacher.shutdown_server, true)
+            for _,t in pairs(warn) do
+                if time >= t then
+                    mc_teacher.restart_scheduled["warn"..tostring(t)] = minetest.after(time - t, mc_teacher.display_restart_time, t)
+                end
+            end
         elseif fields.submitshutdown then
-            if mc_teacher.restart_scheduled.timer then mc_teacher.restart_scheduled.timer:cancel() end
+            mc_teacher.cancel_shutdown()
             mc_teacher.shutdown_server(true)
         elseif fields.addip then
             if fields.ipstart then
                 if not fields.ipend or fields.ipend == "Optional" or fields.ipend == "" then
-                    networking.modify_ipv4(player,fields.ipstart,nil,true)
+                    networking.modify_ipv4(player, fields.ipstart, nil, true)
                 else
-                    networking.modify_ipv4(player,fields.ipstart,fields.ipend,true)
+                    networking.modify_ipv4(player, fields.ipstart, fields.ipend, true)
                 end
             end
             reload = true

--- a/mods/mc_teacher/callbacks.lua
+++ b/mods/mc_teacher/callbacks.lua
@@ -5,23 +5,25 @@ minetest.register_privilege("teacher", {
 
 minetest.register_on_priv_grant(function(name, granter, priv)
     if priv == "teacher" then
-        mc_teacher.teachers[name] = true
+        mc_teacher.register_teacher(name)
     end
+    return true -- continue to next callback
 end)
 
 minetest.register_on_priv_revoke(function(name, revoker, priv)
     if priv == "teacher" then
-        mc_teacher.teachers[name] = nil
+        mc_teacher.register_student(name)
     end
+    return true -- continue to next callback
 end)
 
 -- Teacher joins/leaves
 minetest.register_on_joinplayer(function(player)
 	local pname = player:get_player_name()
 	if minetest.check_player_privs(player, { teacher = true }) then
-		mc_teacher.teachers[pname] = true
+		mc_teacher.register_teacher(pname)
     else
-        mc_teacher.students[pname] = true
+        mc_teacher.register_student(pname)
     end
 
     local teachers = {}
@@ -36,12 +38,7 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_leaveplayer(function(player)
-	local pname = player:get_player_name()
-	if minetest.check_player_privs(player, { teacher = true }) then
-		mc_teacher.teachers[pname] = nil
-	else
-		mc_teacher.students[pname] = nil
-	end
+    mc_teacher.deregister_player(player)
 end)
 
 -- Log all direct messages

--- a/mods/mc_teacher/functions.lua
+++ b/mods/mc_teacher/functions.lua
@@ -1,5 +1,48 @@
 function mc_teacher.shutdown_server(reconnect)
-    minetest.request_shutdown("Server is undergoing a scheduled restart. Please try to reconnect after one minute.",reconnect,0)
+    minetest.request_shutdown("Server is undergoing a scheduled restart. Please try to reconnect after one minute.", reconnect, 0)
+end
+
+function mc_teacher.cancel_shutdown()
+    if mc_teacher.restart_scheduled then
+        for _,timer in pairs(mc_teacher.restart_scheduled) do
+            timer:cancel()
+        end
+    end
+end
+
+function mc_teacher.display_restart_time(time)
+    local extension = " seconds"
+    if time >= 3600 then
+        extension = " hours"
+        time = time / 3600
+    elseif time >= 60 then
+        extension = " minutes"
+        time = time / 60
+    end
+
+    if time == 1 then
+        extension = string.sub(extension, 1, -2)
+    end
+
+    for _,player in pairs(minetest.get_connected_players()) do
+        if player:is_player() then
+            if not mc_core.hud:get(player, "restart_timer") then
+                mc_core.hud:add(player, "restart_timer", {
+                    hud_elem_type = "text",
+                    text = "Server restarting in "..time..extension,
+                    scale = {x = 100, y = 100},
+                    position = {x = 0.5, y = 0.918},
+                    alignment = {x = 0, y = -1},
+                    color = 0xFFFFFF,
+                    style = 0,
+                })
+            else
+                mc_core.hud:change(player, "restart_timer", {
+                    text = "Server restarting in "..time..extension
+                })
+            end
+        end
+    end
 end
 
 function mc_teacher.get_fs_context(player)

--- a/mods/mc_teacher/functions.lua
+++ b/mods/mc_teacher/functions.lua
@@ -22,3 +22,27 @@ function mc_teacher.check_selected_priv_mode(context)
         context.selected_privs_mode = mc_teacher.TABS.PLAYERS
     end
 end
+
+function mc_teacher.register_teacher(player)
+    local pname = (type(player) == "string" and player) or (player:is_player() and player:get_player_name())
+    if pname then
+        mc_teacher.teachers[pname] = true
+        mc_teacher.students[pname] = nil
+    end
+end
+
+function mc_teacher.register_student(player)
+    local pname = (type(player) == "string" and player) or (player:is_player() and player:get_player_name())
+    if pname then
+        mc_teacher.teachers[pname] = nil
+        mc_teacher.students[pname] = true
+    end
+end
+
+function mc_teacher.deregister_player(player)
+    local pname = (type(player) == "string" and player) or (player:is_player() and player:get_player_name())
+    if pname then
+        mc_teacher.teachers[pname] = nil
+        mc_teacher.students[pname] = nil
+    end
+end

--- a/mods/mc_toolhandler/init.lua
+++ b/mods/mc_toolhandler/init.lua
@@ -152,7 +152,7 @@ function mc_toolhandler.register_tool_manager(tool, options)
     minetest.register_on_priv_grant(function(name, granter, priv)
         -- Check if priv has an effect on the privileges needed for the tool
         if name == nil or not mc_core.tableHas(options.privs, priv) or not minetest.get_player_by_name(name) then
-            return true -- skip this callback, continue to next callback
+            return true -- continue to next callback
         end
     
         local stack = ItemStack(tool)
@@ -182,9 +182,9 @@ function mc_toolhandler.register_tool_manager(tool, options)
     minetest.register_on_priv_revoke(function(name, revoker, priv)
         -- Check if priv has an effect on the privileges needed for the tool
         if name == nil or not mc_core.tableHas(options.privs, priv) or not minetest.get_player_by_name(name) then
-            return true -- skip this callback, continue to next callback
+            return true -- continue to next callback
         end
-    
+
         local stack = ItemStack(tool)
         local player = minetest.get_player_by_name(name)
         local list = get_player_item_location(player, stack)
@@ -266,7 +266,7 @@ function mc_toolhandler.register_group_manager(tools, options)
     minetest.register_on_priv_grant(function(name, granter, priv)
         -- Check if priv has an effect on the privileges needed for the tool
         if name == nil or not mc_core.tableHas(options.privs, priv) or not minetest.get_player_by_name(name) then
-            return true -- skip this callback, continue to next callback
+            return true -- continue to next callback
         end
     
         local player = minetest.get_player_by_name(name)
@@ -294,7 +294,7 @@ function mc_toolhandler.register_group_manager(tools, options)
     minetest.register_on_priv_revoke(function(name, revoker, priv)
         -- Check if priv has an effect on the privileges needed for the tool
         if name == nil or not mc_core.tableHas(options.privs, priv) or not minetest.get_player_by_name(name) then
-            return true -- skip this callback, continue to next callback
+            return true -- continue to next callback
         end
         
         local player = minetest.get_player_by_name(name)


### PR DESCRIPTION
Fixes #217, #218, and #219
* Make other priv grant callbacks return true so that `mc_toolhandler` callbacks get run
* Update both `teachers` and `students` lists when privs are updated
* Add notifications for players when server restart is scheduled (chat message + HUD element above hotbar)