### PR TITLE
`networking` mod refactor

### DIFF
--- a/mods/networking/commands.lua
+++ b/mods/networking/commands.lua
@@ -1,5 +1,5 @@
 minetest.register_chatcommand("set_kick_message", {
-	description = "Changes the networking kick message displayed on a failed attempt to join the server from a whitelisted IPV4 address.",
+	description = "Changes the networking kick message displayed on a failed attempt to join the server from a whitelisted IPv4 address.",
 	privs = {server = true},
     params = "<message>",
 	func = function(pname, message)
@@ -18,61 +18,73 @@ minetest.register_chatcommand("get_kick_message", {
 })
 
 minetest.register_chatcommand("add_ipv4", {
-	description = "Adds a single IPV4 address or a comma-separated list of IPV4 addresses to the whitelist.",
+	description = "Adds a single IPv4 address or a comma-separated list of IPv4 addresses to the whitelist.",
 	privs = {server = true},
     params = "<ipv4_addresses>",
 	func = function(pname, ipv4)
         -- Validate entry
-        local addresses = networking.parse(ipv4,",")
+        local addresses = networking.parse(ipv4, ",")
         if #addresses == 0 then
-            -- Empty entry
-            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
-        elseif #addresses == 1 then
-            -- Single entry
-            local octets = networking.parse(ipv4,".")
-            if #octets == 4 then
-                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    if not networking.ipv4_whitelist[ipv4] then
-                        networking.ipv4_whitelist[ipv4] = true
-                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                        minetest.chat_send_player(pname, "[Networking] Success: Added IPV4 address at '"..ipv4.."'.")
-                    else
-                        minetest.chat_send_player(pname, "[Networking] Warning: Input IPV4 address '"..ipv4.."' is already in the whitelist.")
-                    end
-                else
-                    minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-                end
-            else 
-                minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-            end
-        else
-            -- Multiple entries
-            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-            for _,address in pairs(addresses) do
-                local octets = networking.parse(address,".")
-                if #octets == 4 then
-                    if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                        if not networking.ipv4_whitelist[address] then
-                            networking.ipv4_whitelist[address] = true
-                        else
-                            minetest.chat_send_player(pname, "[Networking] Warning: Input IPV4 address '"..address.."' is already in the whitelist.")
-                        end
-                    else
-                        minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
-                    end
-                else
-                    minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0' so skipping input '"..address.."'.")
-                end
-            end
-            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-            minetest.chat_send_player(pname, "[Networking] Success: Added comma-separated list of IPV4 addresses to the whitelist.")
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Empty input. Add an IPv4 address of the format '0.0.0.0' after the chat command and try again.")
         end
+
+        local player = minetest.get_player_by_name(pname)
+        local ctr = 0
+        local ctr_success = 0
+        for _,address in pairs(addresses) do
+            ctr = ctr + 1
+            local success = networking.modify_ipv4(player, address, nil, true)
+            ctr_success = ctr_success + (success and 1 or 0)
+        end
+        minetest.chat_send_player(pname, "[Networking] Successfully added "..ctr_success.." out of "..ctr.." IP addresses to the whitelist.")
 	end
 })
 
 minetest.register_chatcommand("add_ipv4_range", {
-	description = "Adds a range of IPV4 addresses to the whitelist.",
+	description = "Adds a range of IPv4 addresses to the whitelist.",
+	privs = {server = true},
+    params = "<ipv4_address_start> <ipv4_address_end>",
+	func = function(pname, input)
+        -- Validate entry
+        local addresses = networking.parse(input," ")
+        if #addresses == 0 then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Start of IP address range missing. Add an IPv4 address range of the format \'0.0.0.0 1.1.1.1\' after the chat command and try again.")
+        elseif #addresses == 1 then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: End of IP address range missing. Add an IPv4 address range of the format \'0.0.0.0 1.1.1.1\' after the chat command and try again.")
+        end
+
+        local player = minetest.get_player_by_name(pname)
+        local startRange = addresses[1]
+        local endRange = addresses[2]
+        networking.modify_ipv4(player, startRange, endRange, true)
+	end
+})
+
+minetest.register_chatcommand("remove_ipv4", {
+	description = "Removes a single IPv4 address or a comma-separated list of IPv4 addresses from the whitelist.",
+	privs = {server = true},
+    params = "<ipv4_addresses>",
+	func = function(pname, ipv4)
+        -- Validate entry
+        local addresses = networking.parse(ipv4, ",")
+        if #addresses == 0 then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Empty input. Add an IPv4 address of the format \'0.0.0.0\' after the chat command and try again.")
+        end
+
+        local player = minetest.get_player_by_name(pname)
+        local ctr = 0
+        local ctr_success = 0
+        for _,address in pairs(addresses) do
+            ctr = ctr + 1
+            local success = networking.modify_ipv4(player, address, nil, nil)
+            ctr_success = ctr_success + (success and 1 or 0)
+        end
+        minetest.chat_send_player(pname, "[Networking] Successfully removed "..ctr_success.." out of "..ctr.." IP addresses from the whitelist.")
+	end
+})
+
+minetest.register_chatcommand("remove_ipv4_range", {
+	description = "Removes a range of IPv4 addresses from the whitelist.",
 	privs = {server = true},
     params = "<ipv4_address_start> <ipv4_address_end>",
 	func = function(pname, input)
@@ -80,172 +92,26 @@ minetest.register_chatcommand("add_ipv4_range", {
         local addresses = networking.parse(input," ")
         if #addresses == 0 then
             -- Empty entry
-            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Start of IP address range missing. Add an IPv4 address range of the format \'0.0.0.0 1.1.1.1\' after the chat command and try again.")
         elseif #addresses == 1 then
             -- Missing entry
-            minetest.chat_send_player(pname, "[Networking] Error: Input was missing. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-        else
-            -- Completed entry
-            local startRange = addresses[1]
-            local endRange = addresses[2]
-            local startOctets = networking.parse(startRange,".")
-            local endOctets = networking.parse(endRange,".")
-            if #startOctets == 4 and #endOctets == 4 then
-                -- Validate all octets are integers
-                if tonumber(startOctets[1]) and tonumber(startOctets[2]) and tonumber(startOctets[3]) and tonumber(startOctets[4]) and tonumber(endOctets[1]) and tonumber(endOctets[2]) and tonumber(endOctets[3]) and tonumber(endOctets[4]) then
-                    minetest.chat_send_player(pname, "[Networking] Starting to add range of IPV4 addresses to the whitelist, this may take a moment. Please wait for the success message.")
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    networking.counter = 0
-                    if startOctets[1] == endOctets[1] then
-                        if startOctets[2] == endOctets[2] then
-                            if startOctets[3] == endOctets[3] then
-                                if startOctets[4] == endOctets[4] then
-                                    -- Start and end of range are equivalent, so there is only one IPV4 address to add in this range
-                                    networking.ipv4_whitelist[startRange] = true
-                                    networking.counter = networking.counter + 1
-                                else
-                                    -- First three octets are equivalent
-                                    if startOctets[4] < endOctets[4] then
-                                        for oct4=tonumber(startOctets[4]),tonumber(endOctets[4]),1 do
-                                            local address = startOctets[1].."."..startOctets[2].."."..startOctets[3].."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    else
-                                        minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                    end
-                                end
-                            else
-                                -- First two octets are equivalent
-                                if tonumber(startOctets[3]) < tonumber(endOctets[3]) then
-                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = startOctets[1].."."..startOctets[2].."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                else
-                                    minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                end
-                            end
-                        else
-                            -- First octet is equivalent
-                            if tonumber(startOctets[2]) < tonumber(endOctets[2]) then
-                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                    for oct3=tonumber(startOctets[3]),lastOct3,1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = startOctets[1].."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                end
-                            else
-                                minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                return
-                            end
-                        end
-                    else
-                        -- No octets are equivalent
-                        if tonumber(startOctets[1]) < tonumber(endOctets[1]) then
-                            for oct1=tonumber(startOctets[1]),tonumber(endOctets[1]),1 do
-                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = tostring(oct2).."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                end
-                            end
-                        else
-                            minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                            return
-                        end
-                    end
-                    networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                    minetest.chat_send_player(pname, "[Networking] Success: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were added to the whitelist.")
-                else
-                    minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-                    return
-                end
-            else
-                minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-                return
-            end
+            return minetest.chat_send_player(pname, "[Networking] ERROR: End of IP address range missing. Add an IPv4 address range of the format \'0.0.0.0 1.1.1.1\' after the chat command and try again.")
         end
-	end
-})
 
-minetest.register_chatcommand("remove_ipv4", {
-	description = "Removes a single IPV4 address or a comma-separated list of IPV4 addresses from the whitelist.",
-	privs = {server = true},
-    params = "<ipv4_addresses>",
-	func = function(pname, ipv4)
-        -- Validate entry
-        local addresses = networking.parse(ipv4,",")
-        if #addresses == 0 then
-            -- Empty entry
-            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
-        elseif #addresses == 1 then
-            -- Single entry
-            local octets = networking.parse(ipv4,".")
-            if #octets == 4 then
-                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    if networking.ipv4_whitelist[ipv4] then
-                        networking.ipv4_whitelist[ipv4] = nil
-                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                        minetest.chat_send_player(pname, "[Networking] Success: Removed IPV4 address at '"..ipv4.."'.")
-                    else
-                        minetest.chat_send_player(pname, "[Networking] Warning: Did not find IPV4 address '"..ipv4.."' in the whitelist.")
-                    end
-                else
-                    minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-                end
-            else 
-                minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-            end
-        else
-            -- Multiple entries
-            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-            for _,address in pairs(addresses) do
-                local octets = networking.parse(address,".")
-                if #octets == 4 then
-                    if tonumber(octets[1]) and tonumber(octects[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                        if networking.ipv4_whitelist[address] then
-                            networking.ipv4_whitelist[address] = nil
-                            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                            minetest.chat_send_player(pname, "[Networking] Success: Removed IPV4 address at '"..address.."'.")
-                        else
-                            minetest.chat_send_player(pname, "[Networking] Warning: Did not find IPV4 address '"..address.."' in the whitelist.")
-                        end
-                    else
-                        minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
-                    end
-                else
-                    minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Skipping input '"..address.."'.")
-                end
-            end
-            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-            minetest.chat_send_player(pname, "[Networking] Success: Removed comma-separated list of IPV4 addresses to the whitelist.")
-        end
+        local player = minetest.get_player_by_name(pname)
+        local startRange = addresses[1]
+        local endRange = addresses[2]
+        networking.modify_ipv4(player, startRange, endRange, nil)
 	end
 })
 
 minetest.register_chatcommand("clear_whitelist", {
-	description = "Removes all IPV4 addresses from the whitelist except the default address 127.0.0.1 for singleplayer.",
+	description = "Removes all IPv4 addresses from the whitelist except the default address \'127.0.0.1\' for singleplayer.",
 	privs = {server = true},
 	func = function(pname, _)
-        networking.ipv4_whitelist = {}
-        networking.ipv4_whitelist["127.0.0.1"] = true
-        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-        minetest.chat_send_player(pname, "[Networking] Success: Removed all IPV4 addresses from the whitelist.")
+        local ipv4_whitelist = {["127.0.0.1"] = true}
+        networking.storage:set_string("ipv4_whitelist", minetest.serialize(ipv4_whitelist))
+        minetest.chat_send_player(pname, "[Networking] SUCCESS: Removed all IPv4 addresses from the whitelist.")
 	end
 })
 
@@ -253,8 +119,8 @@ minetest.register_chatcommand("dump_whitelist", {
 	description = "Dumps all whitelisted IPV4s into chat.",
 	privs = {server = true},
 	func = function(pname, _)
-        whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-        minetest.chat_send_player(pname, "[Networking] Whitelisted IPV4 addresses:")
+        local whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+        minetest.chat_send_player(pname, "[Networking] Whitelisted IPv4 addresses:")
         for ipv4,_ in pairs(whitelist) do
             minetest.chat_send_player(pname, "[Networking] "..ipv4)
         end
@@ -272,8 +138,8 @@ minetest.register_chatcommand("whitelist", {
         else
 			-- Quick check to ensure current admin player is connected from a whitelisted IP to avoid unintentional lock-out
 			local ipv4 = minetest.get_player_ip(pname)
-			networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-			if not networking.ipv4_whitelist[ipv4] then
+			local ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+			if not ipv4_whitelist[ipv4] then
 				minetest.chat_send_player(pname, "[Networking] WARNING: You need to join from a whitelisted IP address before you can enable the whitelist otherwise you will be locked out of the server.")
 			else
 				networking.storage:set_string("enabled", minetest.serialize(true))

--- a/mods/networking/commands.lua
+++ b/mods/networking/commands.lua
@@ -1,0 +1,285 @@
+minetest.register_chatcommand("set_kick_message", {
+	description = "Changes the networking kick message displayed on a failed attempt to join the server from a whitelisted IPV4 address.",
+	privs = {server = true},
+    params = "<message>",
+	func = function(pname, message)
+        minetest.chat_send_player(pname, "[Networking] Success: Kick message updated to read '"..message.."'")
+        networking.storage:set_string("kick_message", minetest.serialize(message))
+	end
+})
+
+minetest.register_chatcommand("get_kick_message", {
+	description = "Prints the networking kick message to player chat.",
+	privs = {server = true},
+	func = function(pname, message)
+        local message = minetest.deserialize(networking.storage:get_string("kick_message"))
+        minetest.chat_send_player(pname, "[Networking] Kick message currently reads '"..message.."'")
+	end
+})
+
+minetest.register_chatcommand("add_ipv4", {
+	description = "Adds a single IPV4 address or a comma-separated list of IPV4 addresses to the whitelist.",
+	privs = {server = true},
+    params = "<ipv4_addresses>",
+	func = function(pname, ipv4)
+        -- Validate entry
+        local addresses = networking.parse(ipv4,",")
+        if #addresses == 0 then
+            -- Empty entry
+            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
+        elseif #addresses == 1 then
+            -- Single entry
+            local octets = networking.parse(ipv4,".")
+            if #octets == 4 then
+                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
+                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+                    if not networking.ipv4_whitelist[ipv4] then
+                        networking.ipv4_whitelist[ipv4] = true
+                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+                        minetest.chat_send_player(pname, "[Networking] Success: Added IPV4 address at '"..ipv4.."'.")
+                    else
+                        minetest.chat_send_player(pname, "[Networking] Warning: Input IPV4 address '"..ipv4.."' is already in the whitelist.")
+                    end
+                else
+                    minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
+                end
+            else 
+                minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
+            end
+        else
+            -- Multiple entries
+            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+            for _,address in pairs(addresses) do
+                local octets = networking.parse(address,".")
+                if #octets == 4 then
+                    if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
+                        if not networking.ipv4_whitelist[address] then
+                            networking.ipv4_whitelist[address] = true
+                        else
+                            minetest.chat_send_player(pname, "[Networking] Warning: Input IPV4 address '"..address.."' is already in the whitelist.")
+                        end
+                    else
+                        minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
+                    end
+                else
+                    minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0' so skipping input '"..address.."'.")
+                end
+            end
+            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+            minetest.chat_send_player(pname, "[Networking] Success: Added comma-separated list of IPV4 addresses to the whitelist.")
+        end
+	end
+})
+
+minetest.register_chatcommand("add_ipv4_range", {
+	description = "Adds a range of IPV4 addresses to the whitelist.",
+	privs = {server = true},
+    params = "<ipv4_address_start> <ipv4_address_end>",
+	func = function(pname, input)
+        -- Validate entry
+        local addresses = networking.parse(input," ")
+        if #addresses == 0 then
+            -- Empty entry
+            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
+        elseif #addresses == 1 then
+            -- Missing entry
+            minetest.chat_send_player(pname, "[Networking] Error: Input was missing. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
+        else
+            -- Completed entry
+            local startRange = addresses[1]
+            local endRange = addresses[2]
+            local startOctets = networking.parse(startRange,".")
+            local endOctets = networking.parse(endRange,".")
+            if #startOctets == 4 and #endOctets == 4 then
+                -- Validate all octets are integers
+                if tonumber(startOctets[1]) and tonumber(startOctets[2]) and tonumber(startOctets[3]) and tonumber(startOctets[4]) and tonumber(endOctets[1]) and tonumber(endOctets[2]) and tonumber(endOctets[3]) and tonumber(endOctets[4]) then
+                    minetest.chat_send_player(pname, "[Networking] Starting to add range of IPV4 addresses to the whitelist, this may take a moment. Please wait for the success message.")
+                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+                    networking.counter = 0
+                    if startOctets[1] == endOctets[1] then
+                        if startOctets[2] == endOctets[2] then
+                            if startOctets[3] == endOctets[3] then
+                                if startOctets[4] == endOctets[4] then
+                                    -- Start and end of range are equivalent, so there is only one IPV4 address to add in this range
+                                    networking.ipv4_whitelist[startRange] = true
+                                    networking.counter = networking.counter + 1
+                                else
+                                    -- First three octets are equivalent
+                                    if startOctets[4] < endOctets[4] then
+                                        for oct4=tonumber(startOctets[4]),tonumber(endOctets[4]),1 do
+                                            local address = startOctets[1].."."..startOctets[2].."."..startOctets[3].."."..tostring(oct4)
+                                            networking.ipv4_whitelist[address] = true
+                                            networking.counter = networking.counter + 1
+                                        end
+                                    else
+                                        minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
+                                    end
+                                end
+                            else
+                                -- First two octets are equivalent
+                                if tonumber(startOctets[3]) < tonumber(endOctets[3]) then
+                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
+                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
+                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
+                                            local address = startOctets[1].."."..startOctets[2].."."..tostring(oct3).."."..tostring(oct4)
+                                            networking.ipv4_whitelist[address] = true
+                                            networking.counter = networking.counter + 1
+                                        end
+                                    end
+                                else
+                                    minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
+                                end
+                            end
+                        else
+                            -- First octet is equivalent
+                            if tonumber(startOctets[2]) < tonumber(endOctets[2]) then
+                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
+                                    for oct3=tonumber(startOctets[3]),lastOct3,1 do
+                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
+                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
+                                            local address = startOctets[1].."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
+                                            networking.ipv4_whitelist[address] = true
+                                            networking.counter = networking.counter + 1
+                                        end
+                                    end
+                                end
+                            else
+                                minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
+                                return
+                            end
+                        end
+                    else
+                        -- No octets are equivalent
+                        if tonumber(startOctets[1]) < tonumber(endOctets[1]) then
+                            for oct1=tonumber(startOctets[1]),tonumber(endOctets[1]),1 do
+                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
+                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
+                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
+                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
+                                            local address = tostring(oct2).."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
+                                            networking.ipv4_whitelist[address] = true
+                                            networking.counter = networking.counter + 1
+                                        end
+                                    end
+                                end
+                            end
+                        else
+                            minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
+                            return
+                        end
+                    end
+                    networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+                    minetest.chat_send_player(pname, "[Networking] Success: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were added to the whitelist.")
+                else
+                    minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
+                    return
+                end
+            else
+                minetest.chat_send_player(pname, "[Networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
+                return
+            end
+        end
+	end
+})
+
+minetest.register_chatcommand("remove_ipv4", {
+	description = "Removes a single IPV4 address or a comma-separated list of IPV4 addresses from the whitelist.",
+	privs = {server = true},
+    params = "<ipv4_addresses>",
+	func = function(pname, ipv4)
+        -- Validate entry
+        local addresses = networking.parse(ipv4,",")
+        if #addresses == 0 then
+            -- Empty entry
+            minetest.chat_send_player(pname, "[Networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
+        elseif #addresses == 1 then
+            -- Single entry
+            local octets = networking.parse(ipv4,".")
+            if #octets == 4 then
+                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
+                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+                    if networking.ipv4_whitelist[ipv4] then
+                        networking.ipv4_whitelist[ipv4] = nil
+                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+                        minetest.chat_send_player(pname, "[Networking] Success: Removed IPV4 address at '"..ipv4.."'.")
+                    else
+                        minetest.chat_send_player(pname, "[Networking] Warning: Did not find IPV4 address '"..ipv4.."' in the whitelist.")
+                    end
+                else
+                    minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
+                end
+            else 
+                minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
+            end
+        else
+            -- Multiple entries
+            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+            for _,address in pairs(addresses) do
+                local octets = networking.parse(address,".")
+                if #octets == 4 then
+                    if tonumber(octets[1]) and tonumber(octects[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
+                        if networking.ipv4_whitelist[address] then
+                            networking.ipv4_whitelist[address] = nil
+                            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+                            minetest.chat_send_player(pname, "[Networking] Success: Removed IPV4 address at '"..address.."'.")
+                        else
+                            minetest.chat_send_player(pname, "[Networking] Warning: Did not find IPV4 address '"..address.."' in the whitelist.")
+                        end
+                    else
+                        minetest.chat_send_player(pname, "[Networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
+                    end
+                else
+                    minetest.chat_send_player(pname, "[Networking] Error: Expected four octets of format '0.0.0.0'. Skipping input '"..address.."'.")
+                end
+            end
+            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+            minetest.chat_send_player(pname, "[Networking] Success: Removed comma-separated list of IPV4 addresses to the whitelist.")
+        end
+	end
+})
+
+minetest.register_chatcommand("clear_whitelist", {
+	description = "Removes all IPV4 addresses from the whitelist except the default address 127.0.0.1 for singleplayer.",
+	privs = {server = true},
+	func = function(pname, _)
+        networking.ipv4_whitelist = {}
+        networking.ipv4_whitelist["127.0.0.1"] = true
+        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+        minetest.chat_send_player(pname, "[Networking] Success: Removed all IPV4 addresses from the whitelist.")
+	end
+})
+
+minetest.register_chatcommand("dump_whitelist", {
+	description = "Dumps all whitelisted IPV4s into chat.",
+	privs = {server = true},
+	func = function(pname, _)
+        whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+        minetest.chat_send_player(pname, "[Networking] Whitelisted IPV4 addresses:")
+        for ipv4,_ in pairs(whitelist) do
+            minetest.chat_send_player(pname, "[Networking] "..ipv4)
+        end
+	end
+})
+
+minetest.register_chatcommand("whitelist", {
+	description = "Toggles the state of the whitelist between enabled and disabled.",
+	privs = {server = true},
+	func = function(pname, _)
+        local state = minetest.deserialize(networking.storage:get_string("enabled"))
+        if state then
+			networking.storage:set_string("enabled", minetest.serialize(false))
+			minetest.chat_send_player(pname, "[Networking] Whitelist is now disabled.")
+        else
+			-- Quick check to ensure current admin player is connected from a whitelisted IP to avoid unintentional lock-out
+			local ipv4 = minetest.get_player_ip(pname)
+			networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+			if not networking.ipv4_whitelist[ipv4] then
+				minetest.chat_send_player(pname, "[Networking] WARNING: You need to join from a whitelisted IP address before you can enable the whitelist otherwise you will be locked out of the server.")
+			else
+				networking.storage:set_string("enabled", minetest.serialize(true))
+				minetest.chat_send_player(pname, "[Networking] Whitelist is now enabled.")
+			end
+        end
+	end
+})
+

--- a/mods/networking/init.lua
+++ b/mods/networking/init.lua
@@ -11,14 +11,6 @@ if not networking.ipv4_whitelist then
     networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
 end
 
-function networking.parse(s,sep)
-    local values = {}
-    local sep = sep or " "
-    local pattern = string.format("([^%s]+)", sep)
-    string.gsub(s, pattern, function(c) values[#values + 1] = c end)
-    return values
-end
-
 minetest.register_on_joinplayer(function(player) 
     local pname = player:get_player_name()
     local ipv4 = minetest.get_player_ip(pname)
@@ -29,448 +21,151 @@ minetest.register_on_joinplayer(function(player)
     end
 end)
 
-minetest.register_chatcommand("set_kick_message", {
-	description = "Changes the networking kick message displayed on a failed attempt to join the server from a whitelisted IPV4 address.",
-	privs = {server = true},
-    params = "<message>",
-	func = function(pname, message)
-        minetest.chat_send_player(pname,"[networking] Success: Kick message updated to read '"..message.."'")
-        networking.storage:set_string("kick_message", minetest.serialize(message))
-	end
-})
-
-minetest.register_chatcommand("get_kick_message", {
-	description = "Prints the networking kick message to player chat.",
-	privs = {server = true},
-	func = function(pname, message)
-        local message = minetest.deserialize(networking.storage:get_string("kick_message"))
-        minetest.chat_send_player(pname,"[networking] Kick message currently reads '"..message.."'")
-	end
-})
-
-minetest.register_chatcommand("add_ipv4", {
-	description = "Adds a single IPV4 address or a comma-separated list of IPV4 addresses to the whitelist.",
-	privs = {server = true},
-    params = "<ipv4_addresses>",
-	func = function(pname, ipv4)
-        -- Validate entry
-        local addresses = networking.parse(ipv4,",")
-        if #addresses == 0 then
-            -- Empty entry
-            minetest.chat_send_player(pname,"[networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
-        elseif #addresses == 1 then
-            -- Single entry
-            local octets = networking.parse(ipv4,".")
-            if #octets == 4 then
-                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    if not networking.ipv4_whitelist[ipv4] then
-                        networking.ipv4_whitelist[ipv4] = true
-                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                        minetest.chat_send_player(pname,"[networking] Success: Added IPV4 address at '"..ipv4.."'.")
-                    else
-                        minetest.chat_send_player(pname,"[networking] Warning: Input IPV4 address '"..ipv4.."' is already in the whitelist.")
-                    end
-                else
-                    minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-                end
-            else 
-                minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-            end
-        else
-            -- Multiple entries
-            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-            for _,address in pairs(addresses) do
-                local octets = networking.parse(address,".")
-                if #octets == 4 then
-                    if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                        if not networking.ipv4_whitelist[address] then
-                            networking.ipv4_whitelist[address] = true
-                        else
-                            minetest.chat_send_player(pname,"[networking] Warning: Input IPV4 address '"..address.."' is already in the whitelist.")
-                        end
-                    else
-                        minetest.chat_send_player(pname,"[networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
-                    end
-                else
-                    minetest.chat_send_player(pname,"[networking] Warning: Expected four octets of format '0.0.0.0' so skipping input '"..address.."'.")
-                end
-            end
-            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-            minetest.chat_send_player(pname,"[networking] Success: Added comma-separated list of IPV4 addresses to the whitelist.")
-        end
-	end
-})
-
-minetest.register_chatcommand("add_ipv4_range", {
-	description = "Adds a range of IPV4 addresses to the whitelist.",
-	privs = {server = true},
-    params = "<ipv4_address_start> <ipv4_address_end>",
-	func = function(pname, input)
-        -- Validate entry
-        local addresses = networking.parse(input," ")
-        if #addresses == 0 then
-            -- Empty entry
-            minetest.chat_send_player(pname,"[networking] Error: Input was empty. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-        elseif #addresses == 1 then
-            -- Missing entry
-            minetest.chat_send_player(pname,"[networking] Error: Input was missing. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-        else
-            -- Completed entry
-            local startRange = addresses[1]
-            local endRange = addresses[2]
-            local startOctets = networking.parse(startRange,".")
-            local endOctets = networking.parse(endRange,".")
-            if #startOctets == 4 and #endOctets == 4 then
-                -- Validate all octets are integers
-                if tonumber(startOctets[1]) and tonumber(startOctets[2]) and tonumber(startOctets[3]) and tonumber(startOctets[4]) and tonumber(endOctets[1]) and tonumber(endOctets[2]) and tonumber(endOctets[3]) and tonumber(endOctets[4]) then
-                    minetest.chat_send_player(pname,"[networking] Starting to add range of IPV4 addresses to the whitelist, this may take a moment. Please wait for the success message.")
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    networking.counter = 0
-                    if startOctets[1] == endOctets[1] then
-                        if startOctets[2] == endOctets[2] then
-                            if startOctets[3] == endOctets[3] then
-                                if startOctets[4] == endOctets[4] then
-                                    -- Start and end of range are equivalent, so there is only one IPV4 address to add in this range
-                                    networking.ipv4_whitelist[startRange] = true
-                                    networking.counter = networking.counter + 1
-                                else
-                                    -- First three octets are equivalent
-                                    if startOctets[4] < endOctets[4] then
-                                        for oct4=tonumber(startOctets[4]),tonumber(endOctets[4]),1 do
-                                            local address = startOctets[1].."."..startOctets[2].."."..startOctets[3].."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    else
-                                        minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                    end
-                                end
-                            else
-                                -- First two octets are equivalent
-                                if tonumber(startOctets[3]) < tonumber(endOctets[3]) then
-                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = startOctets[1].."."..startOctets[2].."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                else
-                                    minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                end
-                            end
-                        else
-                            -- First octet is equivalent
-                            if tonumber(startOctets[2]) < tonumber(endOctets[2]) then
-                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                    for oct3=tonumber(startOctets[3]),lastOct3,1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = startOctets[1].."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                end
-                            else
-                                minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                return
-                            end
-                        end
-                    else
-                        -- No octets are equivalent
-                        if tonumber(startOctets[1]) < tonumber(endOctets[1]) then
-                            for oct1=tonumber(startOctets[1]),tonumber(endOctets[1]),1 do
-                                for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                    for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                        if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                        for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                            local address = tostring(oct2).."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                            networking.ipv4_whitelist[address] = true
-                                            networking.counter = networking.counter + 1
-                                        end
-                                    end
-                                end
-                            end
-                        else
-                            minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                            return
-                        end
-                    end
-                    networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                    minetest.chat_send_player(pname,"[networking] Success: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were added to the whitelist.")
-                else
-                    minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-                    return
-                end
-            else
-                minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. Add an IPV4 address range of the format '0.0.0.0 1.1.1.1' after the chat command and try again.")
-                return
-            end
-        end
-	end
-})
-
-function networking.modify_ipv4(player,startRange,endRange,add)
-    if mc_core.checkPrivs(player,{server = true}) then
-        local pname = player:get_player_name()
-        local startOctets, endOctets
-        -- Validate entry
-        if not startRange or startRange == "" then
-            minetest.chat_send_player(pname,"[networking] Error: Input was empty. Add an IPV4 address in the format '0.0.0.0'.")
-        elseif #startRange > 15 then
-            minetest.chat_send_player(pname,"[networking] Error: Input start range value had more characters than expected. Check the input string is no larger than the format '000.000.000.000'.")
-        elseif #startRange < 7 then
-            minetest.chat_send_player(pname,"[networking] Error: Input start range value had fewer characters than expected. Check the input string is no smaller than the format '0.0.0.0'.'")
-        else
-            startOctets = networking.parse(startRange,".")
-            -- Check if endRange was specified, otherwise treat as a single entry
-            if endRange then
-                if #endRange > 15 then
-                    minetest.chat_send_player(pname,"[networking] Error: Input end range value had more characters than expected. Check the input string is no larger than the format '000.000.000.000'.")
-                elseif #endRange < 7 then
-                    minetest.chat_send_player(pname,"[networking] Error: Input end range value had fewer characters than expected. Check the input string is no smaller than the format '0.0.0.0'.'")
-                else
-                    endOctets = networking.parse(endRange,".")
-                    if #startOctets == 4 and #endOctets == 4 then
-                        -- Validate all octets are integers
-                        if tonumber(startOctets[1]) and tonumber(startOctets[2]) and tonumber(startOctets[3]) and tonumber(startOctets[4]) and tonumber(endOctets[1]) and tonumber(endOctets[2]) and tonumber(endOctets[3]) and tonumber(endOctets[4]) then
-                            minetest.chat_send_player(pname,"[networking] Starting to add range of IPV4 addresses to the whitelist, this may take a moment. Please wait for the success message.")
-                            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                            networking.counter = 0
-                            if startOctets[1] == endOctets[1] then
-                                if startOctets[2] == endOctets[2] then
-                                    if startOctets[3] == endOctets[3] then
-                                        if startOctets[4] == endOctets[4] then
-                                            -- Start and end of range are equivalent, so there is only one IPV4 address to add in this range
-                                            networking.ipv4_whitelist[startRange] = add
-                                            networking.counter = networking.counter + 1
-                                        else
-                                            -- First three octets are equivalent
-                                            if startOctets[4] < endOctets[4] then
-                                                for oct4=tonumber(startOctets[4]),tonumber(endOctets[4]),1 do
-                                                    local address = startOctets[1].."."..startOctets[2].."."..startOctets[3].."."..tostring(oct4)
-                                                    networking.ipv4_whitelist[address] = add
-                                                    networking.counter = networking.counter + 1
-                                                end
-                                            else
-                                                minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                            end
-                                        end
-                                    else
-                                        -- First two octets are equivalent
-                                        if tonumber(startOctets[3]) < tonumber(endOctets[3]) then
-                                            for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                                if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                                for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                                    local address = startOctets[1].."."..startOctets[2].."."..tostring(oct3).."."..tostring(oct4)
-                                                    networking.ipv4_whitelist[address] = add
-                                                    networking.counter = networking.counter + 1
-                                                end
-                                            end
-                                        else
-                                            minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                        end
-                                    end
-                                else
-                                    -- First octet is equivalent
-                                    if tonumber(startOctets[2]) < tonumber(endOctets[2]) then
-                                        for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                            for oct3=tonumber(startOctets[3]),lastOct3,1 do
-                                                if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                                for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                                    local address = startOctets[1].."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                                    networking.ipv4_whitelist[address] = add
-                                                    networking.counter = networking.counter + 1
-                                                end
-                                            end
-                                        end
-                                    else
-                                        minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                        return
-                                    end
-                                end
-                            else
-                                -- No octets are equivalent
-                                if tonumber(startOctets[1]) < tonumber(endOctets[1]) then
-                                    for oct1=tonumber(startOctets[1]),tonumber(endOctets[1]),1 do
-                                        for oct2=tonumber(startOctets[2]),tonumber(endOctets[2]),1 do
-                                            for oct3=tonumber(startOctets[3]),tonumber(endOctets[3]),1 do
-                                                if oct3 == tonumber(endOctets[3]) then lastOct = tonumber(endOctets[4]) else lastOct = 255 end
-                                                for oct4=tonumber(startOctets[4]),lastOct,1 do
-                                                    local address = tostring(oct2).."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
-                                                    networking.ipv4_whitelist[address] = add
-                                                    networking.counter = networking.counter + 1
-                                                end
-                                            end
-                                        end
-                                    end
-                                else
-                                    minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. The start of the range comes after the end of the range. Check input and try again.")
-                                    return
-                                end
-                            end
-                            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                            if add then
-                                minetest.chat_send_player(pname,"[networking] Success: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were added to the whitelist.")
-                            else
-                                minetest.chat_send_player(pname,"[networking] Success: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were removed from the whitelist.")
-                            end
-                        else
-                            minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. Check the input string is in the format of '0.0.0.0'.")
-                            return
-                        end
-                    else
-                        minetest.chat_send_player(pname,"[networking] Error: Input '"..input.."' was misspecified. Check the input string is in the format of '0.0.0.0'.")
-                        return
-                    end
-                end
-            else
-                if #startOctets == 4 then
-                    if tonumber(startOctets[1]) and tonumber(startOctets[2]) and tonumber(startOctets[3]) and tonumber(startOctets[4]) then
-                        networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                        if not networking.ipv4_whitelist[startRange] then
-                            networking.ipv4_whitelist[startRange] = add
-                            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                            if add then
-                                minetest.chat_send_player(pname,"[networking] Success: Added IPV4 address at '"..startRange.."'.")
-                            else
-                                minetest.chat_send_player(pname,"[networking] Success: Removed IPV4 address at '"..startRange.."'.")
-                            end
-                        else
-                            minetest.chat_send_player(pname,"[networking] Warning: Input IPV4 address '"..startRange.."' is already in the whitelist.")
-                        end
-                    else
-                        minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..startRange.."' and try again.")
-                    end
-                else 
-                    minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..startRange.."' and try again.")
-                end
-            end
-        end
-    else
-        minetest.chat_send_player(pname,"[networking] Error: You do not have the Server privilege to run this function.")
+local function escape_sep(sep)
+    local magic = {"^", "$", "(", ")", "%", ".", "[", "]", "*", "+", "-", "?"}
+    local output = sep
+    for _,char in pairs(magic) do
+        output = string.gsub(output, "%"..char, "%%%0")
     end
+    return output
 end
 
-minetest.register_chatcommand("remove_ipv4", {
-	description = "Removes a single IPV4 address or a comma-separated list of IPV4 addresses from the whitelist.",
-	privs = {server = true},
-    params = "<ipv4_addresses>",
-	func = function(pname, ipv4)
-        -- Validate entry
-        local addresses = networking.parse(ipv4,",")
-        if #addresses == 0 then
-            -- Empty entry
-            minetest.chat_send_player(pname,"[networking] Error: Input was empty. Add an IPV4 address of the format '0.0.0.0' after the chat command and try again.")
-        elseif #addresses == 1 then
-            -- Single entry
-            local octets = networking.parse(ipv4,".")
-            if #octets == 4 then
-                if tonumber(octets[1]) and tonumber(octets[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                    networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-                    if networking.ipv4_whitelist[ipv4] then
-                        networking.ipv4_whitelist[ipv4] = nil
-                        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                        minetest.chat_send_player(pname,"[networking] Success: Removed IPV4 address at '"..ipv4.."'.")
-                    else
-                        minetest.chat_send_player(pname,"[networking] Warning: Did not find IPV4 address '"..ipv4.."' in the whitelist.")
-                    end
-                else
-                    minetest.chat_send_player(pname,"[networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-                end
-            else 
-                minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Check input '"..ipv4.."' and try again.")
-            end
-        else
-            -- Multiple entries
-            networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-            for _,address in pairs(addresses) do
-                local octets = networking.parse(address,".")
-                if #octets == 4 then
-                    if tonumber(octets[1]) and tonumber(octects[2]) and tonumber(octets[3]) and tonumber(octets[4]) then
-                        if networking.ipv4_whitelist[address] then
-                            networking.ipv4_whitelist[address] = nil
-                            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-                            minetest.chat_send_player(pname,"[networking] Success: Removed IPV4 address at '"..address.."'.")
-                        else
-                            minetest.chat_send_player(pname,"[networking] Warning: Did not find IPV4 address '"..address.."' in the whitelist.")
-                        end
-                    else
-                        minetest.chat_send_player(pname,"[networking] Warning: Expected four octets of format '0.0.0.0'. Check input '"..address.."' and try again.")
-                    end
-                else
-                    minetest.chat_send_player(pname,"[networking] Error: Expected four octets of format '0.0.0.0'. Skipping input '"..address.."'.")
-                end
-            end
-            networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-            minetest.chat_send_player(pname,"[networking] Success: Removed comma-separated list of IPV4 addresses to the whitelist.")
-        end
-	end
-})
+function networking.parse(s, sep)
+    local values = {}
+    local sep = sep or " "
+    for match in string.gmatch(s..sep, "(.-)"..escape_sep(sep)) do
+        table.insert(values, match);
+    end
+    return values
+end
 
-minetest.register_chatcommand("clear_whitelist", {
-	description = "Removes all IPV4 addresses from the whitelist except the default address 127.0.0.1 for singleplayer.",
-	privs = {server = true},
-	func = function(pname, _)
-        networking.ipv4_whitelist = {}
-        networking.ipv4_whitelist["127.0.0.1"] = true
+---Returns true if IP address a comes before or is identical to IP address b
+---This function can be used as a comparison function for table.sort
+---If either input is not an IP address, sorts valid IP addresses before other inputs
+function networking.ipv4_compare(a, b)
+    if not a or not b then
+        return not b
+    end
+
+    local ip_a = networking.parse(a, ".")
+    local ip_b = networking.parse(b, ".")
+    if #ip_a ~= 4 or #ip_b ~= 4 then
+        return #ip_b ~= 4
+    elseif tonumber(ip_a[1]) and tonumber(ip_b[1]) then
+        if tonumber(ip_a[1]) ~= tonumber(ip_b[1]) then
+            return tonumber(ip_a[1]) < tonumber(ip_b[1])
+        elseif tonumber(ip_a[2]) and tonumber(ip_b[2]) then
+            if tonumber(ip_a[2]) ~= tonumber(ip_b[2]) then
+                return tonumber(ip_a[2]) < tonumber(ip_b[2])
+            elseif tonumber(ip_a[3]) and tonumber(ip_b[3]) then
+                if tonumber(ip_a[3]) ~= tonumber(ip_b[3]) then
+                    return tonumber(ip_a[3]) < tonumber(ip_b[3])
+                elseif tonumber(ip_a[4]) and tonumber(ip_b[4]) then
+                    return tonumber(ip_a[4]) <= tonumber(ip_b[4])
+                end
+            end
+        end
+    end
+    return a < b
+end
+
+function networking.modify_ipv4(player, startRange, endRange, add)
+    local pname = player:get_player_name()
+    if not mc_core.checkPrivs(player, {server = true}) then
+        return minetest.chat_send_player(pname, "[Networking] ERROR: You do not have the server privilege, which is required to run this function.")
+    end
+
+    -- Validate start octets
+    if not startRange or startRange == "" then
+        return minetest.chat_send_player(pname, "[Networking] ERROR: Input was empty. Add an IPV4 address in the format '0.0.0.0'.")
+    end
+    local startOctets = networking.parse(startRange, ".")
+    if #startOctets ~= 4 or not tonumber(startOctets[1]) or not tonumber(startOctets[2]) or not tonumber(startOctets[3]) or not tonumber(startOctets[4]) then
+        return minetest.chat_send_player(pname, "[Networking] ERROR: Expected start range to be four octets of format '0.0.0.0'. Check input '"..startRange.."' and try again.")
+    end
+    for i, octet in ipairs(startOctets) do
+        if #octet > 3 then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Octet "..i.." of start range had more characters than expected. Check that the input string is no larger than the format '000.000.000.000'.")
+        elseif #octet < 1 then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Octet "..i.." of start range had fewer characters than expected. Check that the input string is no smaller than the format '0.0.0.0'.'")
+        end
+    end
+
+    -- Check if endRange was specified, otherwise treat as a single entry
+    if endRange then
+        -- Validate end octets, if specified
+        local endOctets = networking.parse(endRange, ".")
+        if #endOctets ~= 4 or not tonumber(endOctets[1]) or not tonumber(endOctets[2]) or not tonumber(endOctets[3]) or not tonumber(endOctets[4]) then
+            return minetest.chat_send_player(pname, "[Networking] ERROR: Expected end range to be four octets of format '0.0.0.0'. Check input '"..endRange.."' and try again.")
+        end
+        for i, octet in ipairs(endOctets) do
+            if #octet > 3 then
+                return minetest.chat_send_player(pname, "[Networking] ERROR: Octet "..i.." of end range had more characters than expected. Check that the input string is no larger than the format '000.000.000.000'.")
+            elseif #octet < 1 then
+                return minetest.chat_send_player(pname, "[Networking] ERROR: Octet "..i.." of end range had fewer characters than expected. Check that the input string is no smaller than the format '0.0.0.0'.'")
+            end
+        end
+
+        if not networking.ipv4_compare(startRange, endRange) then
+            return minetest.chat_send_player(pname, "[Networking] Error: Input was misspecified. The start of the range comes after the end of the range. Check your input and try again.")
+        end
+
+        minetest.chat_send_player(pname, "[Networking] Starting to process specified range of IPv4 addresses, this may take a moment. Please wait for the success message.")
+        networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+        networking.counter = 0
+
+        for oct1 = tonumber(startOctets[1]), tonumber(endOctets[1]), 1 do
+            local lastOct2 = oct1 == tonumber(endOctets[1])
+            for oct2 = tonumber(startOctets[2]), (lastOct2 and tonumber(endOctets[2]) or 255), 1 do
+                local lastOct3 = lastOct2 and oct2 == tonumber(endOctets[2])
+                for oct3 = tonumber(startOctets[3]), (lastOct3 and tonumber(endOctets[3]) or 255), 1 do
+                    local lastOct4 = lastOct3 and oct3 == tonumber(endOctets[3])
+                    for oct4 = tonumber(startOctets[4]), (lastOct4 and tonumber(endOctets[4]) or 255), 1 do
+                        local address = tostring(oct1).."."..tostring(oct2).."."..tostring(oct3).."."..tostring(oct4)
+                        networking.ipv4_whitelist[address] = add
+                        networking.counter = networking.counter + 1
+                    end
+                end
+            end
+        end
+
         networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
-        minetest.chat_send_player(pname,"[networking] Success: Removed all IPV4 addresses from the whitelist.")
-	end
-})
-
-minetest.register_chatcommand("dump_whitelist", {
-	description = "Dumps all whitelisted IPV4s into chat.",
-	privs = {server = true},
-	func = function(pname, _)
-        whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-        minetest.chat_send_player(pname,"[networking] Whitelisted IPV4 addresses:")
-        for ipv4,_ in pairs(whitelist) do
-            minetest.chat_send_player(pname,"[networking] "..ipv4)
-        end
-	end
-})
-
-minetest.register_chatcommand("whitelist", {
-	description = "Toggles the state of the whitelist between enabled and disabled.",
-	privs = {server = true},
-	func = function(pname, _)
-        local state = minetest.deserialize(networking.storage:get_string("enabled"))
-        if state then
-			networking.storage:set_string("enabled", minetest.serialize(false))
-			minetest.chat_send_player(pname,"[networking] Whitelist is now disabled.")
+        if add then
+            minetest.chat_send_player(pname, "[Networking] SUCCESS: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were added to the whitelist.")
         else
-			-- Quick check to ensure current admin player is connected from a whitelisted IP to avoid unintentional lock-out
-			local ipv4 = minetest.get_player_ip(pname)
-			networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
-			if not networking.ipv4_whitelist[ipv4] then
-				minetest.chat_send_player(pname,"[networking] WARNING: You need to join from a whitelisted IP address before you can enable the whitelist otherwise you will be locked out of the server.")
-			else
-				networking.storage:set_string("enabled", minetest.serialize(true))
-				minetest.chat_send_player(pname,"[networking] Whitelist is now enabled.")
-			end
+            minetest.chat_send_player(pname, "[Networking] SUCCESS: Total of "..tostring(networking.counter).." IPV4 addresses in range of "..startRange.." to "..endRange.." were removed from the whitelist.")
         end
-	end
-})
+    else
+        networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
+        local address = tostring(tonumber(startOctets[1])).."."..tostring(tonumber(startOctets[2])).."."..tostring(tonumber(startOctets[3])).."."..tostring(tonumber(startOctets[4]))
+        networking.ipv4_whitelist[address] = add
+        networking.storage:set_string("ipv4_whitelist", minetest.serialize(networking.ipv4_whitelist))
+        if add then
+            minetest.chat_send_player(pname, "[Networking] SUCCESS: Added IPV4 address at '"..startRange.."'.")
+        else
+            minetest.chat_send_player(pname, "[Networking] SUCCESS: Removed IPV4 address at '"..startRange.."'.")
+        end
+    end
+end
 
 function networking.toggle_whitelist(player)
     local pname = player:get_player_name()
     local state = minetest.deserialize(networking.storage:get_string("enabled"))
     if state then
 		networking.storage:set_string("enabled", minetest.serialize(false))
-		minetest.chat_send_player(pname,"[networking] Whitelist is now disabled.")
+		minetest.chat_send_player(pname, "[Networking] Whitelist is now disabled.")
     else
 		-- Quick check to ensure current admin player is connected from a whitelisted IP to avoid unintentional lock-out
 		local ipv4 = minetest.get_player_ip(pname)
 		networking.ipv4_whitelist = minetest.deserialize(networking.storage:get_string("ipv4_whitelist"))
 		if not networking.ipv4_whitelist[ipv4] then
-			minetest.chat_send_player(pname,"[networking] WARNING: You need to join from a whitelisted IP address before you can enable the whitelist otherwise you will be locked out of the server.")
+			minetest.chat_send_player(pname, "[Networking] WARNING: You need to join from a whitelisted IP address before you can enable the whitelist otherwise you will be locked out of the server.")
 		else
 			networking.storage:set_string("enabled", minetest.serialize(true))
-			minetest.chat_send_player(pname,"[networking] Whitelist is now enabled.")
+			minetest.chat_send_player(pname, "[Networking] Whitelist is now enabled.")
 		end
     end
 end
+
+-- Register chat commands
+dofile(minetest.get_modpath("networking") .. "/commands.lua")

--- a/mods/networking/mod.conf
+++ b/mods/networking/mod.conf
@@ -1,0 +1,2 @@
+name = networking
+description = Provides utilities for managing the server whitelist


### PR DESCRIPTION
Refactors some of the code in the `networking` mod, and fixes some crashes that could occur when handling large IP ranges
* Add missing `mod.conf` file
* Move chat commands to `networking/commands.lua`
  * Add `remove_ipv4_range` chat command
  * Refactor commands to use `networking.modify_ipv4`
* Prevent `127.0.0.1` (singleplayer IP) from being removed from the whitelist